### PR TITLE
Execute Rubocop with GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,17 +18,6 @@ jobs:
               --out test_results/rspec.xml \
               --format progress
 
-  rubocop:
-    docker:
-      - image: circleci/ruby:2.6.3-stretch-node
-    executor: ruby/default
-    steps:
-      - checkout
-      - ruby/bundle-install
-      - run:
-          name: rubocop
-          command: bundle exec rubocop
-
   deploy:
     docker:
       - image: circleci/ruby:2.6.3-stretch-node
@@ -60,7 +49,6 @@ workflows:
   ci:
     jobs:
       - rspec
-      - rubocop
   rubygems-deploy:
     jobs:
       - deploy:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          rubocop_version: 0.82.0
+          rubocop_version: 0.86.0

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,15 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  rubocop:
+    name: runner / rubocop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: rubocop
+        uses: reviewdog/action-rubocop@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          rubocop_version: 0.82.0

--- a/lib/puppeteer/browser.rb
+++ b/lib/puppeteer/browser.rb
@@ -155,10 +155,7 @@ class Puppeteer::Browser
   # @param {!Protocol.Target.targetInfoChangedPayload} event
   def handle_target_info_changed(event)
     target_info = Puppeteer::Target::TargetInfo.new(event['targetInfo'])
-    target = @targets[target_info.target_id]
-    unless target
-      raise TargetNotExistError.new
-    end
+    target = @targets[target_info.target_id] or raise TargetNotExistError.new
     previous_url = target.url
     was_initialized = target.initialized?
     target.handle_target_info_changed(target_info)

--- a/lib/puppeteer/frame_manager.rb
+++ b/lib/puppeteer/frame_manager.rb
@@ -341,11 +341,7 @@ class Puppeteer::FrameManager
   end
 
   def execution_context_by_id(context_id)
-    context = @context_id_to_context[context_id]
-    unless context
-      raise "INTERNAL ERROR: missing context with id = #{context_id}"
-    end
-    context
+    @context_id_to_context[context_id] or raise "INTERNAL ERROR: missing context with id = #{context_id}"
   end
 
   # @param {!Frame} frame

--- a/puppeteer-ruby.gemspec
+++ b/puppeteer-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter' # for CircleCI.
-  spec.add_development_dependency 'rubocop', '~> 0.82.0'
+  spec.add_development_dependency 'rubocop', '~> 0.86.0'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
also, Style/AndOr is updated after rubocop 0.83.
https://github.com/rubocop-hq/rubocop/pull/7959

Revert the proper usage of or.