### PR TITLE
replace async def ... with define_async_method

### DIFF
--- a/lib/puppeteer.rb
+++ b/lib/puppeteer.rb
@@ -8,8 +8,8 @@ require 'puppeteer/errors'
 require 'puppeteer/viewport'
 
 # Modules
-require 'puppeteer/async_await_behavior'
 require 'puppeteer/concurrent_ruby_utils'
+require 'puppeteer/define_async_method'
 require 'puppeteer/debug_print'
 require 'puppeteer/event_callbackable'
 require 'puppeteer/if_present'

--- a/lib/puppeteer/async_await_behavior.rb
+++ b/lib/puppeteer/async_await_behavior.rb
@@ -1,5 +1,23 @@
 module Puppeteer::AsyncAwaitBehavior
   refine Class do
+    def define_async_method_for(method_name)
+      original_method = instance_method(method_name)
+      async_method_name = "async_#{method_name}"
+
+      if method_defined?(async_method_name) || private_method_defined?(async_method_name)
+        raise ArgumentError.new("#{async_method_name} is already defined")
+      end
+
+      define_method(async_method_name) do |*args|
+        Concurrent::Promises.future do
+          original_method.bind(self).call(*args)
+        rescue => err
+          Logger.new(STDERR).warn(err)
+          raise err
+        end
+      end
+    end
+
     # wrap with Concurrent::Promises.future
     def async(method_name)
       original_method = instance_method(method_name)

--- a/lib/puppeteer/async_await_behavior.rb
+++ b/lib/puppeteer/async_await_behavior.rb
@@ -17,40 +17,5 @@ module Puppeteer::AsyncAwaitBehavior
         end
       end
     end
-
-    # wrap with Concurrent::Promises.future
-    def async(method_name)
-      original_method = instance_method(method_name)
-
-      unless method_name.to_s.start_with?('async_')
-        puts "async method should start with 'async_': #{self.name}##{method_name}"
-      end
-
-      define_method(method_name) do |*args|
-        Concurrent::Promises.future do
-          original_method.bind(self).call(*args)
-        rescue => err
-          Logger.new(STDERR).warn(err)
-          raise err
-        end
-      end
-    rescue NameError
-      if respond_to?(method_name)
-        original_method = singleton_method(method_name)
-
-        unless method_name.to_s.start_with?('async_')
-          puts "async method should start with 'async_': #{method_name}"
-        end
-
-        define_singleton_method(method_name) do |*args|
-          Concurrent::Promises.future do
-            original_method.call(*args)
-          rescue => err
-            Logger.new(STDERR).warn(err)
-            raise err
-          end
-        end
-      end
-    end
   end
 end

--- a/lib/puppeteer/browser.rb
+++ b/lib/puppeteer/browser.rb
@@ -5,7 +5,7 @@ class Puppeteer::Browser
   include Puppeteer::DebugPrint
   include Puppeteer::EventCallbackable
   include Puppeteer::IfPresent
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param {!Puppeteer.Connection} connection
   # @param {!Array<string>} contextIds

--- a/lib/puppeteer/cdp_session.rb
+++ b/lib/puppeteer/cdp_session.rb
@@ -1,7 +1,7 @@
 class Puppeteer::CDPSession
   include Puppeteer::DebugPrint
   include Puppeteer::EventCallbackable
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   class Error < StandardError; end
 

--- a/lib/puppeteer/connection.rb
+++ b/lib/puppeteer/connection.rb
@@ -210,9 +210,7 @@ class Puppeteer::Connection
     end
   end
 
-  private async def async_handle_message(message)
-    handle_message(message)
-  end
+  private define_async_method_for :handle_message
 
   private def handle_close
     return if @closed

--- a/lib/puppeteer/connection.rb
+++ b/lib/puppeteer/connection.rb
@@ -3,7 +3,7 @@ require 'json'
 class Puppeteer::Connection
   include Puppeteer::DebugPrint
   include Puppeteer::EventCallbackable
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   class ProtocolError < StandardError
     def initialize(method:, error_message:, error_data: nil)

--- a/lib/puppeteer/connection.rb
+++ b/lib/puppeteer/connection.rb
@@ -210,7 +210,7 @@ class Puppeteer::Connection
     end
   end
 
-  private define_async_method_for :handle_message
+  private define_async_method :async_handle_message
 
   private def handle_close
     return if @closed

--- a/lib/puppeteer/define_async_method.rb
+++ b/lib/puppeteer/define_async_method.rb
@@ -1,13 +1,15 @@
 module Puppeteer::DefineAsyncMethod
   refine Class do
-    def define_async_method_for(method_name)
-      original_method = instance_method(method_name)
-      async_method_name = "async_#{method_name}"
+    def define_async_method(async_method_name)
+      unless async_method_name.to_s.start_with?('async_')
+        raise ArgumentError.new('async method name should start with "async_"')
+      end
 
       if method_defined?(async_method_name) || private_method_defined?(async_method_name)
         raise ArgumentError.new("#{async_method_name} is already defined")
       end
 
+      original_method = instance_method(async_method_name[6..-1])
       define_method(async_method_name) do |*args|
         Concurrent::Promises.future do
           original_method.bind(self).call(*args)

--- a/lib/puppeteer/define_async_method.rb
+++ b/lib/puppeteer/define_async_method.rb
@@ -1,4 +1,4 @@
-module Puppeteer::AsyncAwaitBehavior
+module Puppeteer::DefineAsyncMethod
   refine Class do
     def define_async_method_for(method_name)
       original_method = instance_method(method_name)

--- a/lib/puppeteer/dom_world.rb
+++ b/lib/puppeteer/dom_world.rb
@@ -2,7 +2,7 @@ require 'thread'
 
 # https://github.com/puppeteer/puppeteer/blob/master/src/DOMWorld.js
 class Puppeteer::DOMWorld
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param {!Puppeteer.FrameManager} frameManager
   # @param {!Puppeteer.Frame} frame

--- a/lib/puppeteer/element_handle.rb
+++ b/lib/puppeteer/element_handle.rb
@@ -4,7 +4,7 @@ require_relative './element_handle/point'
 
 class Puppeteer::ElementHandle < Puppeteer::JSHandle
   include Puppeteer::IfPresent
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param context [Puppeteer::ExecutionContext]
   # @param client [Puppeteer::CDPSession]

--- a/lib/puppeteer/element_handle.rb
+++ b/lib/puppeteer/element_handle.rb
@@ -105,11 +105,11 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     end
   end
 
-  #  async hover() {
-  #    await this._scrollIntoViewIfNeeded();
-  #    const {x, y} = await this._clickablePoint();
-  #    await this._page.mouse.move(x, y);
-  #  }
+  def hover
+    scroll_into_view_if_needed
+    point = clickable_point
+    @page.mouse.move(point.x, point.y)
+  end
 
   # @param delay [Number]
   # @param button [String] "left"|"right"|"middle"
@@ -120,12 +120,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.mouse.click(point.x, point.y, delay: delay, button: button, click_count: click_count)
   end
 
-  # @param delay [Number]
-  # @param button [String] "left"|"right"|"middle"
-  # @param click_count [Number]
-  async def async_click(delay: nil, button: nil, click_count: nil)
-    click(delay: delay, button: button, click_count: click_count)
-  end
+  define_async_method_for :click
 
   # @return [Array<String>]
   def select(*values)
@@ -195,17 +190,13 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.touchscreen.tap(point.x, point.y)
   end
 
-  async def async_tap
-    tap
-  end
+  define_async_method_for :tap
 
   def focus
     evaluate('element => element.focus()')
   end
 
-  async def async_focus
-    focus
-  end
+  define_async_method_for :focus
 
   # @param text [String]
   # @param delay [number|nil]
@@ -214,12 +205,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.keyboard.type_text(text, delay: delay)
   end
 
-  # @param text [String]
-  # @param delay [number|nil]
-  # @return [Future]
-  async def async_type_text(text, delay: nil)
-    type_text(text, delay: delay)
-  end
+  define_async_method_for :type_text
 
   # @param key [String]
   # @param delay [number|nil]
@@ -228,12 +214,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.keyboard.press(key, delay: delay)
   end
 
-  # @param key [String]
-  # @param delay [number|nil]
-  # @return [Future]
-  async def async_press(key, delay: nil)
-    press(key, delay: delay)
-  end
+  define_async_method_for :press
 
   # @return [BoundingBox|nil]
   def bounding_box
@@ -356,13 +337,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     result
   end
 
-  # `$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
-  # @param selector [String]
-  # @param page_function [String]
-  # @return [Object]
-  async def async_Seval(selector, page_function, *args)
-    Seval(selector, page_function, *args)
-  end
+  define_async_method_for :Seval
 
   # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param selector [String]
@@ -379,13 +354,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     result
   end
 
-  # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
-  # @param selector [String]
-  # @param page_function [String]
-  # @return [Object]
-  async def async_SSeval(selector, page_function, *args)
-    SSeval(selector, page_function, *args)
-  end
+  define_async_method_for :SSeval
 
   # `$x()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param expression [String]
@@ -407,6 +376,8 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     handles.dispose
     properties.values.map(&:as_element).compact
   end
+
+  define_async_method_for :Sx
 
   #  /**
   #   * @returns {!Promise<boolean>}

--- a/lib/puppeteer/element_handle.rb
+++ b/lib/puppeteer/element_handle.rb
@@ -120,7 +120,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.mouse.click(point.x, point.y, delay: delay, button: button, click_count: click_count)
   end
 
-  define_async_method_for :click
+  define_async_method :async_click
 
   # @return [Array<String>]
   def select(*values)
@@ -190,13 +190,13 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.touchscreen.tap(point.x, point.y)
   end
 
-  define_async_method_for :tap
+  define_async_method :async_tap
 
   def focus
     evaluate('element => element.focus()')
   end
 
-  define_async_method_for :focus
+  define_async_method :async_focus
 
   # @param text [String]
   # @param delay [number|nil]
@@ -205,7 +205,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.keyboard.type_text(text, delay: delay)
   end
 
-  define_async_method_for :type_text
+  define_async_method :async_type_text
 
   # @param key [String]
   # @param delay [number|nil]
@@ -214,7 +214,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     @page.keyboard.press(key, delay: delay)
   end
 
-  define_async_method_for :press
+  define_async_method :async_press
 
   # @return [BoundingBox|nil]
   def bounding_box
@@ -337,7 +337,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     result
   end
 
-  define_async_method_for :Seval
+  define_async_method :async_Seval
 
   # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param selector [String]
@@ -354,7 +354,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     result
   end
 
-  define_async_method_for :SSeval
+  define_async_method :async_SSeval
 
   # `$x()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param expression [String]
@@ -377,7 +377,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
     properties.values.map(&:as_element).compact
   end
 
-  define_async_method_for :Sx
+  define_async_method :async_Sx
 
   #  /**
   #   * @returns {!Promise<boolean>}

--- a/lib/puppeteer/emulation_manager.rb
+++ b/lib/puppeteer/emulation_manager.rb
@@ -38,9 +38,5 @@ class Puppeteer::EmulationManager
     reload_needed
   end
 
-  # @param viewport [Puppeteer::Viewport]
-  # @return [Future<true|false>]
-  async def async_emulate_viewport(viewport)
-    emulate_viewport(viewport)
-  end
+  define_async_method_for :emulate_viewport
 end

--- a/lib/puppeteer/emulation_manager.rb
+++ b/lib/puppeteer/emulation_manager.rb
@@ -1,5 +1,5 @@
 class Puppeteer::EmulationManager
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param {!Puppeteer.CDPSession} client
   def initialize(client)

--- a/lib/puppeteer/emulation_manager.rb
+++ b/lib/puppeteer/emulation_manager.rb
@@ -38,5 +38,5 @@ class Puppeteer::EmulationManager
     reload_needed
   end
 
-  define_async_method_for :emulate_viewport
+  define_async_method :async_emulate_viewport
 end

--- a/lib/puppeteer/execution_context.rb
+++ b/lib/puppeteer/execution_context.rb
@@ -1,6 +1,6 @@
 class Puppeteer::ExecutionContext
   include Puppeteer::IfPresent
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   EVALUATION_SCRIPT_URL = '__puppeteer_evaluation_script__'
   SOURCE_URL_REGEX = /^[\040\t]*\/\/[@#] sourceURL=\s*(\S*?)\s*$/m

--- a/lib/puppeteer/frame.rb
+++ b/lib/puppeteer/frame.rb
@@ -1,5 +1,5 @@
 class Puppeteer::Frame
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param {!FrameManager} frameManager
   # @param {!Puppeteer.CDPSession} client

--- a/lib/puppeteer/frame.rb
+++ b/lib/puppeteer/frame.rb
@@ -39,12 +39,7 @@ class Puppeteer::Frame
     @frame_manager.wait_for_frame_navigation(self, timeout: timeout, wait_until: wait_until)
   end
 
-  # @param timeout [number|nil]
-  # @param wait_until [string|nil] 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2'
-  # @return [Future]
-  async def async_wait_for_navigation(timeout: nil, wait_until: nil)
-    wait_for_navigation(timeout: timeout, wait_until: wait_until)
-  end
+  define_async_method_for :wait_for_navigation
 
   def execution_context
     @main_world.execution_context
@@ -56,11 +51,15 @@ class Puppeteer::Frame
     @main_world.evaluate_handle(page_function, *args)
   end
 
+  define_async_method_for :evaluate_handle
+
   # @param {Function|string} pageFunction
   # @param {!Array<*>} args
   def evaluate(page_function, *args)
     @main_world.evaluate(page_function, *args)
   end
+
+  define_async_method_for :evaluate
 
   # `$()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
@@ -69,6 +68,7 @@ class Puppeteer::Frame
     @main_world.S(selector)
   end
 
+  define_async_method_for :S
 
   # `$x()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} expression
@@ -77,6 +77,7 @@ class Puppeteer::Frame
     @main_world.Sx(expression)
   end
 
+  define_async_method_for :Sx
 
   # `$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
@@ -87,6 +88,8 @@ class Puppeteer::Frame
     @main_world.Seval(selector, page_function, *args)
   end
 
+  define_async_method_for :Seval
+
   # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
   # @param {Function|string} pageFunction
@@ -96,12 +99,16 @@ class Puppeteer::Frame
     @main_world.SSeval(selector, page_function, *args)
   end
 
+  define_async_method_for :SSeval
+
   # `$$()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
   # @return {!Promise<!Array<!Puppeteer.ElementHandle>>}
   def SS(selector)
     @main_world.SS(selector)
   end
+
+  define_async_method_for :SS
 
   def content
     @secondary_world.content
@@ -156,23 +163,18 @@ class Puppeteer::Frame
   # @param delay [Number]
   # @param button [String] "left"|"right"|"middle"
   # @param click_count [Number]
-  # @return [Future]
-  async def async_click(selector, delay: nil, button: nil, click_count: nil)
-    click(selector, delay: delay, button: button, click_count: click_count)
-  end
-
-  # @param selector [String]
-  # @param delay [Number]
-  # @param button [String] "left"|"right"|"middle"
-  # @param click_count [Number]
   def click(selector, delay: nil, button: nil, click_count: nil)
     @secondary_world.click(selector, delay: delay, button: button, click_count: click_count)
   end
+
+  define_async_method_for :click
 
   # @param {string} selector
   def focus(selector)
     @secondary_world.focus(selector)
   end
+
+  define_async_method_for :focus
 
   # @param {string} selector
   def hover(selector)
@@ -186,10 +188,14 @@ class Puppeteer::Frame
     @secondary_world.select(selector, *values)
   end
 
+  define_async_method_for :select
+
   # @param {string} selector
   def tap(selector)
     @secondary_world.tap(selector)
   end
+
+  define_async_method_for :tap
 
   # @param selector [String]
   # @param text [String]
@@ -197,6 +203,8 @@ class Puppeteer::Frame
   def type_text(selector, text, delay: nil)
     @main_world.type_text(selector, text, delay: delay)
   end
+
+  define_async_method_for :type_text
 
   # /**
   #  * @param {(string|number|Function)} selectorOrFunctionOrTimeout
@@ -235,6 +243,8 @@ class Puppeteer::Frame
     result
   end
 
+  define_async_method_for :wait_for_selector
+
   # @param xpath [String]
   # @param visible [Boolean] Wait for element visible (not 'display: none' nor 'visibility: hidden') on true. default to false.
   # @param hidden [Boolean] Wait for element invisible ('display: none' nor 'visibility: hidden') on true. default to false.
@@ -250,6 +260,8 @@ class Puppeteer::Frame
     result
   end
 
+  define_async_method_for :wait_for_xpath
+
   # @param {Function|string} pageFunction
   # @param {!{polling?: string|number, timeout?: number}=} options
   # @param {!Array<*>} args
@@ -257,6 +269,8 @@ class Puppeteer::Frame
   def wait_for_function(page_function, options = {}, *args)
     @main_world.wait_for_function(page_function, options, *args)
   end
+
+  define_async_method_for :wait_for_function
 
   # @return [String]
   def title

--- a/lib/puppeteer/frame.rb
+++ b/lib/puppeteer/frame.rb
@@ -39,7 +39,7 @@ class Puppeteer::Frame
     @frame_manager.wait_for_frame_navigation(self, timeout: timeout, wait_until: wait_until)
   end
 
-  define_async_method_for :wait_for_navigation
+  define_async_method :async_wait_for_navigation
 
   def execution_context
     @main_world.execution_context
@@ -51,7 +51,7 @@ class Puppeteer::Frame
     @main_world.evaluate_handle(page_function, *args)
   end
 
-  define_async_method_for :evaluate_handle
+  define_async_method :async_evaluate_handle
 
   # @param {Function|string} pageFunction
   # @param {!Array<*>} args
@@ -59,7 +59,7 @@ class Puppeteer::Frame
     @main_world.evaluate(page_function, *args)
   end
 
-  define_async_method_for :evaluate
+  define_async_method :async_evaluate
 
   # `$()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
@@ -68,7 +68,7 @@ class Puppeteer::Frame
     @main_world.S(selector)
   end
 
-  define_async_method_for :S
+  define_async_method :async_S
 
   # `$x()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} expression
@@ -77,7 +77,7 @@ class Puppeteer::Frame
     @main_world.Sx(expression)
   end
 
-  define_async_method_for :Sx
+  define_async_method :async_Sx
 
   # `$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
@@ -88,7 +88,7 @@ class Puppeteer::Frame
     @main_world.Seval(selector, page_function, *args)
   end
 
-  define_async_method_for :Seval
+  define_async_method :async_Seval
 
   # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
@@ -99,7 +99,7 @@ class Puppeteer::Frame
     @main_world.SSeval(selector, page_function, *args)
   end
 
-  define_async_method_for :SSeval
+  define_async_method :async_SSeval
 
   # `$$()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
@@ -108,7 +108,7 @@ class Puppeteer::Frame
     @main_world.SS(selector)
   end
 
-  define_async_method_for :SS
+  define_async_method :async_SS
 
   def content
     @secondary_world.content
@@ -167,14 +167,14 @@ class Puppeteer::Frame
     @secondary_world.click(selector, delay: delay, button: button, click_count: click_count)
   end
 
-  define_async_method_for :click
+  define_async_method :async_click
 
   # @param {string} selector
   def focus(selector)
     @secondary_world.focus(selector)
   end
 
-  define_async_method_for :focus
+  define_async_method :async_focus
 
   # @param {string} selector
   def hover(selector)
@@ -188,14 +188,14 @@ class Puppeteer::Frame
     @secondary_world.select(selector, *values)
   end
 
-  define_async_method_for :select
+  define_async_method :async_select
 
   # @param {string} selector
   def tap(selector)
     @secondary_world.tap(selector)
   end
 
-  define_async_method_for :tap
+  define_async_method :async_tap
 
   # @param selector [String]
   # @param text [String]
@@ -204,7 +204,7 @@ class Puppeteer::Frame
     @main_world.type_text(selector, text, delay: delay)
   end
 
-  define_async_method_for :type_text
+  define_async_method :async_type_text
 
   # /**
   #  * @param {(string|number|Function)} selectorOrFunctionOrTimeout
@@ -243,7 +243,7 @@ class Puppeteer::Frame
     result
   end
 
-  define_async_method_for :wait_for_selector
+  define_async_method :async_wait_for_selector
 
   # @param xpath [String]
   # @param visible [Boolean] Wait for element visible (not 'display: none' nor 'visibility: hidden') on true. default to false.
@@ -260,7 +260,7 @@ class Puppeteer::Frame
     result
   end
 
-  define_async_method_for :wait_for_xpath
+  define_async_method :async_wait_for_xpath
 
   # @param {Function|string} pageFunction
   # @param {!{polling?: string|number, timeout?: number}=} options
@@ -270,7 +270,7 @@ class Puppeteer::Frame
     @main_world.wait_for_function(page_function, options, *args)
   end
 
-  define_async_method_for :wait_for_function
+  define_async_method :async_wait_for_function
 
   # @return [String]
   def title

--- a/lib/puppeteer/frame_manager.rb
+++ b/lib/puppeteer/frame_manager.rb
@@ -4,7 +4,7 @@ class Puppeteer::FrameManager
   include Puppeteer::DebugPrint
   include Puppeteer::IfPresent
   include Puppeteer::EventCallbackable
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   UTILITY_WORLD_NAME = '__puppeteer_utility_world__'
 

--- a/lib/puppeteer/frame_manager.rb
+++ b/lib/puppeteer/frame_manager.rb
@@ -74,9 +74,7 @@ class Puppeteer::FrameManager
     @network_manager.init
   end
 
-  async def async_init
-    init
-  end
+  define_async_method_for :init
 
   attr_reader :network_manager
 

--- a/lib/puppeteer/frame_manager.rb
+++ b/lib/puppeteer/frame_manager.rb
@@ -74,7 +74,7 @@ class Puppeteer::FrameManager
     @network_manager.init
   end
 
-  define_async_method_for :init
+  define_async_method :async_init
 
   attr_reader :network_manager
 

--- a/lib/puppeteer/js_handle.rb
+++ b/lib/puppeteer/js_handle.rb
@@ -46,7 +46,7 @@ class Puppeteer::JSHandle
     execution_context.evaluate(page_function, self, *args)
   end
 
-  define_async_method_for :evaluate
+  define_async_method :async_evaluate
 
   # @param page_function [String]
   # @param args {Array<*>}
@@ -55,7 +55,7 @@ class Puppeteer::JSHandle
     execution_context.evaluate_handle(page_function, self, *args)
   end
 
-  define_async_method_for :evaluate_handle
+  define_async_method :async_evaluate_handle
 
   # /**
   #  * @param {string} propertyName

--- a/lib/puppeteer/js_handle.rb
+++ b/lib/puppeteer/js_handle.rb
@@ -1,5 +1,5 @@
 class Puppeteer::JSHandle
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param context [Puppeteer::ExecutionContext]
   # @param remote_object [Puppeteer::RemoteObject]

--- a/lib/puppeteer/js_handle.rb
+++ b/lib/puppeteer/js_handle.rb
@@ -46,11 +46,7 @@ class Puppeteer::JSHandle
     execution_context.evaluate(page_function, self, *args)
   end
 
-  # @param page_function [String]
-  # @return [Future<Object>]
-  async def async_evaluate(page_function, *args)
-    evaluate(page_function, *args)
-  end
+  define_async_method_for :evaluate
 
   # @param page_function [String]
   # @param args {Array<*>}
@@ -59,12 +55,7 @@ class Puppeteer::JSHandle
     execution_context.evaluate_handle(page_function, self, *args)
   end
 
-  # @param page_function [String]
-  # @param args {Array<*>}
-  # @return [Future<Puppeteer::JSHandle>]
-  async def async_evaluate_handle(page_function, *args)
-    evaluate_handle(page_function, *args)
-  end
+  define_async_method_for :evaluate_handle
 
   # /**
   #  * @param {string} propertyName

--- a/lib/puppeteer/keyboard.rb
+++ b/lib/puppeteer/keyboard.rb
@@ -38,7 +38,7 @@ class Puppeteer::Keyboard
     @client.send_message('Input.dispatchKeyEvent', params)
   end
 
-  define_async_method_for :down
+  define_async_method :async_down
 
   # @param {string} key
   # @return {number}
@@ -122,14 +122,14 @@ class Puppeteer::Keyboard
     )
   end
 
-  define_async_method_for :up
+  define_async_method :async_up
 
   # @param char [string]
   def send_character(char)
     @client.send_message('Input.insertText', text: char)
   end
 
-  define_async_method_for :send_character
+  define_async_method :async_send_character
 
   # @param text [String]
   # @return [Future]
@@ -146,7 +146,7 @@ class Puppeteer::Keyboard
     end
   end
 
-  define_async_method_for :type_text
+  define_async_method :async_type_text
 
   # @param key [String]
   # @return [Future]
@@ -158,5 +158,5 @@ class Puppeteer::Keyboard
     up(key)
   end
 
-  define_async_method_for :press
+  define_async_method :async_press
 end

--- a/lib/puppeteer/keyboard.rb
+++ b/lib/puppeteer/keyboard.rb
@@ -2,7 +2,7 @@ require_relative './keyboard/key_description'
 require_relative './keyboard/us_keyboard_layout'
 
 class Puppeteer::Keyboard
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param {!Puppeteer.CDPSession} client
   def initialize(client)

--- a/lib/puppeteer/keyboard.rb
+++ b/lib/puppeteer/keyboard.rb
@@ -38,12 +38,7 @@ class Puppeteer::Keyboard
     @client.send_message('Input.dispatchKeyEvent', params)
   end
 
-  # @param key [String]
-  # @param text [String]
-  # @return [Future]
-  async def async_down(key, text: nil)
-    down(key, text)
-  end
+  define_async_method_for :down
 
   # @param {string} key
   # @return {number}
@@ -127,22 +122,14 @@ class Puppeteer::Keyboard
     )
   end
 
-  # @param key [String]
-  # @return [Future]
-  async def async_up(key)
-    up(key)
-  end
+  define_async_method_for :up
 
   # @param char [string]
   def send_character(char)
     @client.send_message('Input.insertText', text: char)
   end
 
-  # @param char [string]
-  # @return [Future]
-  async def async_send_character(char)
-    send_character(char)
-  end
+  define_async_method_for :send_character
 
   # @param text [String]
   # @return [Future]
@@ -159,11 +146,7 @@ class Puppeteer::Keyboard
     end
   end
 
-  # @param text [String]
-  # @return [Future]
-  async def async_type_text(text, delay: nil)
-    type_text(text, delay)
-  end
+  define_async_method_for :type_text
 
   # @param key [String]
   # @return [Future]
@@ -175,9 +158,5 @@ class Puppeteer::Keyboard
     up(key)
   end
 
-  # @param key [String]
-  # @return [Future]
-  async def async_press(key, delay: nil)
-    press(key, delay: delay)
-  end
+  define_async_method_for :press
 end

--- a/lib/puppeteer/mouse.rb
+++ b/lib/puppeteer/mouse.rb
@@ -1,5 +1,5 @@
 class Puppeteer::Mouse
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   module Button
     NONE = 'none'

--- a/lib/puppeteer/mouse.rb
+++ b/lib/puppeteer/mouse.rb
@@ -44,13 +44,7 @@ class Puppeteer::Mouse
     end
   end
 
-  # @param x [number]
-  # @param y [number]
-  # @param steps [number]
-  # @return [Future]
-  async def async_move(x, y, steps: nil)
-    move(x, y, steps: steps)
-  end
+  define_async_method_for :move
 
   # @param x [number]
   # @param y [number]
@@ -70,13 +64,7 @@ class Puppeteer::Mouse
     up(button: button, click_count: click_count)
   end
 
-  # @param x [number]
-  # @param y [number]
-  # @param {!{delay?: number, button?: "left"|"right"|"middle", clickCount?: number}=} options
-  # @return [Future]
-  async def async_click(x, y, delay: nil, button: nil, click_count: nil)
-    click(x, y, delay: delay, button: button, click_count: click_count)
-  end
+  define_async_method_for :click
 
   # @param {!{button?: "left"|"right"|"middle", clickCount?: number}=} options
   def down(button: nil, click_count: nil)
@@ -91,11 +79,7 @@ class Puppeteer::Mouse
     )
   end
 
-  # @param {!{button?: "left"|"right"|"middle", clickCount?: number}=} options
-  # @return [Future]
-  async def async_down(button: nil, click_count: nil)
-    down(button: button, click_count: click_count)
-  end
+  define_async_method_for :down
 
   # @param {!{button?: "left"|"right"|"middle", clickCount?: number}=} options
   def up(button: nil, click_count: nil)
@@ -110,9 +94,5 @@ class Puppeteer::Mouse
     )
   end
 
-  # @param {!{button?: "left"|"right"|"middle", clickCount?: number}=} options
-  # @return [Future]
-  async def async_up(button: nil, click_count: nil)
-    up(button: button, click_count: click_count)
-  end
+  define_async_method_for :up
 end

--- a/lib/puppeteer/mouse.rb
+++ b/lib/puppeteer/mouse.rb
@@ -44,7 +44,7 @@ class Puppeteer::Mouse
     end
   end
 
-  define_async_method_for :move
+  define_async_method :async_move
 
   # @param x [number]
   # @param y [number]
@@ -64,7 +64,7 @@ class Puppeteer::Mouse
     up(button: button, click_count: click_count)
   end
 
-  define_async_method_for :click
+  define_async_method :async_click
 
   # @param {!{button?: "left"|"right"|"middle", clickCount?: number}=} options
   def down(button: nil, click_count: nil)
@@ -79,7 +79,7 @@ class Puppeteer::Mouse
     )
   end
 
-  define_async_method_for :down
+  define_async_method :async_down
 
   # @param {!{button?: "left"|"right"|"middle", clickCount?: number}=} options
   def up(button: nil, click_count: nil)
@@ -94,5 +94,5 @@ class Puppeteer::Mouse
     )
   end
 
-  define_async_method_for :up
+  define_async_method :async_up
 end

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -5,7 +5,7 @@ require_relative './page/screenshot_options'
 class Puppeteer::Page
   include Puppeteer::EventCallbackable
   include Puppeteer::IfPresent
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param {!Puppeteer.CDPSession} client
   # @param {!Puppeteer.Target} target

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -205,12 +205,7 @@ class Puppeteer::Page
     end
   end
 
-  # @param timeout [Integer]
-  # @return [Future<Puppeteer::FileChooser>]
-  async def async_wait_for_file_chooser(timeout: nil)
-    wait_for_file_chooser(timeout: timeout)
-  end
-
+  define_async_method_for :wait_for_file_chooser
 
   # /**
   #  * @param {!{longitude: number, latitude: number, accuracy: (number|undefined)}} options
@@ -305,12 +300,16 @@ class Puppeteer::Page
     main_frame.S(selector)
   end
 
+  define_async_method_for :S
+
   # `$$()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
   # @return {!Promise<!Array<!Puppeteer.ElementHandle>>}
   def SS(selector)
     main_frame.SS(selector)
   end
+
+  define_async_method_for :SS
 
   # @param {Function|string} pageFunction
   # @param {!Array<*>} args
@@ -319,6 +318,8 @@ class Puppeteer::Page
     context = main_frame.execution_context
     context.evaluate_handle(page_function, *args)
   end
+
+  define_async_method_for :evaluate_handle
 
   # @param {!Puppeteer.JSHandle} prototypeHandle
   # @return {!Promise<!Puppeteer.JSHandle>}
@@ -335,13 +336,7 @@ class Puppeteer::Page
     main_frame.Seval(selector, page_function, *args)
   end
 
-  # `$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
-  # @param selector [String]
-  # @param page_function [String]
-  # @return [Future]
-  async def async_Seval(selector, page_function, *args)
-    Seval(selector, page_function, *args)
-  end
+  define_async_method_for :Seval
 
   # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param selector [String]
@@ -351,13 +346,7 @@ class Puppeteer::Page
     main_frame.SSeval(selector, page_function, *args)
   end
 
-  # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
-  # @param selector [String]
-  # @param page_function [String]
-  # @return [Future]
-  async def async_SSeval(selector, page_function, *args)
-    SSeval(selector, page_function, *args)
-  end
+  define_async_method_for :SSeval
 
   # `$x()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} expression
@@ -365,6 +354,8 @@ class Puppeteer::Page
   def Sx(expression)
     main_frame.Sx(expression)
   end
+
+  define_async_method_for :Sx
 
   # /**
   #  * @param {!Array<string>} urls
@@ -693,12 +684,7 @@ class Puppeteer::Page
     main_frame.send(:wait_for_navigation, timeout: timeout, wait_until: wait_until)
   end
 
-  # @param timeout [number|nil]
-  # @param wait_until [string|nil] 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2'
-  # @return [Future]
-  async def async_wait_for_navigation(timeout: nil, wait_until: nil)
-    wait_for_navigation(timeout: timeout, wait_until: wait_until)
-  end
+  define_async_method_for :wait_for_navigation
 
   # /**
   #  * @param {(string|Function)} urlOrPredicate
@@ -830,6 +816,8 @@ class Puppeteer::Page
   def evaluate(page_function, *args)
     main_frame.evaluate(page_function, *args)
   end
+
+  define_async_method_for :evaluate
 
   # /**
   #  * @param {Function|string} pageFunction
@@ -1009,19 +997,14 @@ class Puppeteer::Page
     main_frame.click(selector, delay: delay, button: button, click_count: click_count)
   end
 
-  # @param selector [String]
-  # @param delay [Number]
-  # @param button [String] "left"|"right"|"middle"
-  # @param click_count [Number]
-  # @return [Future]
-  async def async_click(selector, delay: nil, button: nil, click_count: nil)
-    click(selector, delay: delay, button: button, click_count: click_count)
-  end
+  define_async_method_for :click
 
   # @param {string} selector
   def focus(selector)
     main_frame.focus(selector)
   end
+
+  define_async_method_for :focus
 
   # @param {string} selector
   def hover(selector)
@@ -1035,15 +1018,14 @@ class Puppeteer::Page
     main_frame.select(selector, *values)
   end
 
+  define_async_method_for :select
+
   # @param selector [String]
   def tap(selector)
     main_frame.tap(selector)
   end
 
-  # @param selector [String]
-  async def async_tap(selector)
-    tap(selector)
-  end
+  define_async_method_for :tap
 
   # @param selector [String]
   # @param text [String]
@@ -1051,6 +1033,8 @@ class Puppeteer::Page
   def type_text(selector, text, delay: nil)
     main_frame.type_text(selector, text, delay: delay)
   end
+
+  define_async_method_for :type_text
 
   # /**
   #  * @param {(string|number|Function)} selectorOrFunctionOrTimeout
@@ -1070,13 +1054,7 @@ class Puppeteer::Page
     main_frame.wait_for_selector(selector, visible: visible, hidden: hidden, timeout: timeout)
   end
 
-  # @param selector [String]
-  # @param visible [Boolean] Wait for element visible (not 'display: none' nor 'visibility: hidden') on true. default to false.
-  # @param hidden [Boolean] Wait for element invisible ('display: none' nor 'visibility: hidden') on true. default to false.
-  # @param timeout [Integer]
-  async def async_wait_for_selector(selector, visible: nil, hidden: nil, timeout: nil)
-    wait_for_selector(selector, visible: visible, hidden: hidden, timeout: timeout)
-  end
+  define_async_method_for :wait_for_selector
 
   # @param xpath [String]
   # @param visible [Boolean] Wait for element visible (not 'display: none' nor 'visibility: hidden') on true. default to false.
@@ -1086,13 +1064,7 @@ class Puppeteer::Page
     main_frame.wait_for_xpath(xpath, visible: visible, hidden: hidden, timeout: timeout)
   end
 
-  # @param xpath [String]
-  # @param visible [Boolean] Wait for element visible (not 'display: none' nor 'visibility: hidden') on true. default to false.
-  # @param hidden [Boolean] Wait for element invisible ('display: none' nor 'visibility: hidden') on true. default to false.
-  # @param timeout [Integer]
-  async def async_wait_for_xpath(xpath, visible: nil, hidden: nil, timeout: nil)
-    wait_for_xpath(xpath, visible: visible, hidden: hidden, timeout: timeout)
-  end
+  define_async_method_for :wait_for_xpath
 
   # @param {Function|string} pageFunction
   # @param {!{polling?: string|number, timeout?: number}=} options
@@ -1101,4 +1073,6 @@ class Puppeteer::Page
   def wait_for_function(page_function, options = {}, *args)
     main_frame.wait_for_function(page_function, options, *args)
   end
+
+  define_async_method_for :wait_for_function
 end

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -205,7 +205,7 @@ class Puppeteer::Page
     end
   end
 
-  define_async_method_for :wait_for_file_chooser
+  define_async_method :async_wait_for_file_chooser
 
   # /**
   #  * @param {!{longitude: number, latitude: number, accuracy: (number|undefined)}} options
@@ -300,7 +300,7 @@ class Puppeteer::Page
     main_frame.S(selector)
   end
 
-  define_async_method_for :S
+  define_async_method :async_S
 
   # `$$()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} selector
@@ -309,7 +309,7 @@ class Puppeteer::Page
     main_frame.SS(selector)
   end
 
-  define_async_method_for :SS
+  define_async_method :async_SS
 
   # @param {Function|string} pageFunction
   # @param {!Array<*>} args
@@ -319,7 +319,7 @@ class Puppeteer::Page
     context.evaluate_handle(page_function, *args)
   end
 
-  define_async_method_for :evaluate_handle
+  define_async_method :async_evaluate_handle
 
   # @param {!Puppeteer.JSHandle} prototypeHandle
   # @return {!Promise<!Puppeteer.JSHandle>}
@@ -336,7 +336,7 @@ class Puppeteer::Page
     main_frame.Seval(selector, page_function, *args)
   end
 
-  define_async_method_for :Seval
+  define_async_method :async_Seval
 
   # `$$eval()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param selector [String]
@@ -346,7 +346,7 @@ class Puppeteer::Page
     main_frame.SSeval(selector, page_function, *args)
   end
 
-  define_async_method_for :SSeval
+  define_async_method :async_SSeval
 
   # `$x()` in JavaScript. $ is not allowed to use as a method name in Ruby.
   # @param {string} expression
@@ -355,7 +355,7 @@ class Puppeteer::Page
     main_frame.Sx(expression)
   end
 
-  define_async_method_for :Sx
+  define_async_method :async_Sx
 
   # /**
   #  * @param {!Array<string>} urls
@@ -684,7 +684,7 @@ class Puppeteer::Page
     main_frame.send(:wait_for_navigation, timeout: timeout, wait_until: wait_until)
   end
 
-  define_async_method_for :wait_for_navigation
+  define_async_method :async_wait_for_navigation
 
   # /**
   #  * @param {(string|Function)} urlOrPredicate
@@ -817,7 +817,7 @@ class Puppeteer::Page
     main_frame.evaluate(page_function, *args)
   end
 
-  define_async_method_for :evaluate
+  define_async_method :async_evaluate
 
   # /**
   #  * @param {Function|string} pageFunction
@@ -997,14 +997,14 @@ class Puppeteer::Page
     main_frame.click(selector, delay: delay, button: button, click_count: click_count)
   end
 
-  define_async_method_for :click
+  define_async_method :async_click
 
   # @param {string} selector
   def focus(selector)
     main_frame.focus(selector)
   end
 
-  define_async_method_for :focus
+  define_async_method :async_focus
 
   # @param {string} selector
   def hover(selector)
@@ -1018,14 +1018,14 @@ class Puppeteer::Page
     main_frame.select(selector, *values)
   end
 
-  define_async_method_for :select
+  define_async_method :async_select
 
   # @param selector [String]
   def tap(selector)
     main_frame.tap(selector)
   end
 
-  define_async_method_for :tap
+  define_async_method :async_tap
 
   # @param selector [String]
   # @param text [String]
@@ -1034,7 +1034,7 @@ class Puppeteer::Page
     main_frame.type_text(selector, text, delay: delay)
   end
 
-  define_async_method_for :type_text
+  define_async_method :async_type_text
 
   # /**
   #  * @param {(string|number|Function)} selectorOrFunctionOrTimeout
@@ -1054,7 +1054,7 @@ class Puppeteer::Page
     main_frame.wait_for_selector(selector, visible: visible, hidden: hidden, timeout: timeout)
   end
 
-  define_async_method_for :wait_for_selector
+  define_async_method :async_wait_for_selector
 
   # @param xpath [String]
   # @param visible [Boolean] Wait for element visible (not 'display: none' nor 'visibility: hidden') on true. default to false.
@@ -1064,7 +1064,7 @@ class Puppeteer::Page
     main_frame.wait_for_xpath(xpath, visible: visible, hidden: hidden, timeout: timeout)
   end
 
-  define_async_method_for :wait_for_xpath
+  define_async_method :async_wait_for_xpath
 
   # @param {Function|string} pageFunction
   # @param {!{polling?: string|number, timeout?: number}=} options
@@ -1074,5 +1074,5 @@ class Puppeteer::Page
     main_frame.wait_for_function(page_function, options, *args)
   end
 
-  define_async_method_for :wait_for_function
+  define_async_method :async_wait_for_function
 end

--- a/lib/puppeteer/remote_object.rb
+++ b/lib/puppeteer/remote_object.rb
@@ -111,10 +111,7 @@ class Puppeteer::RemoteObject
     nil
   end
 
-  # @param client [Puppeteer::CDPSession]
-  async def async_release(client)
-    release(client)
-  end
+  define_async_method_for :release
 
   def converted_arg
     # ported logic from ExecutionContext#convertArgument

--- a/lib/puppeteer/remote_object.rb
+++ b/lib/puppeteer/remote_object.rb
@@ -1,7 +1,7 @@
 # providing #valueFromRemoteObject, #releaseObject
 class Puppeteer::RemoteObject
   include Puppeteer::DebugPrint
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param payload [Hash]
   def initialize(payload)

--- a/lib/puppeteer/remote_object.rb
+++ b/lib/puppeteer/remote_object.rb
@@ -111,7 +111,7 @@ class Puppeteer::RemoteObject
     nil
   end
 
-  define_async_method_for :release
+  define_async_method :async_release
 
   def converted_arg
     # ported logic from ExecutionContext#convertArgument

--- a/lib/puppeteer/touch_screen.rb
+++ b/lib/puppeteer/touch_screen.rb
@@ -1,5 +1,5 @@
 class Puppeteer::TouchScreen
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   # @param {Puppeteer.CDPSession} client
   # @param keyboard [Puppeteer::Keyboard]

--- a/lib/puppeteer/touch_screen.rb
+++ b/lib/puppeteer/touch_screen.rb
@@ -34,10 +34,5 @@ class Puppeteer::TouchScreen
     )
   end
 
-  # @param x [number]
-  # @param y [number]
-  # @return [Future]
-  async def async_tap(x, y)
-    tap(x, y)
-  end
+  define_async_method_for :tap
 end

--- a/lib/puppeteer/touch_screen.rb
+++ b/lib/puppeteer/touch_screen.rb
@@ -34,5 +34,5 @@ class Puppeteer::TouchScreen
     )
   end
 
-  define_async_method_for :tap
+  define_async_method :async_tap
 end

--- a/lib/puppeteer/wait_task.rb
+++ b/lib/puppeteer/wait_task.rb
@@ -1,5 +1,5 @@
 class Puppeteer::WaitTask
-  using Puppeteer::AsyncAwaitBehavior
+  using Puppeteer::DefineAsyncMethod
 
   class TerminatedError < StandardError; end
 

--- a/lib/puppeteer/wait_task.rb
+++ b/lib/puppeteer/wait_task.rb
@@ -106,7 +106,7 @@ class Puppeteer::WaitTask
     @dom_world._wait_tasks.delete(self)
   end
 
-  private define_async_method_for :rerun
+  private define_async_method :async_rerun
 
   WAIT_FOR_PREDICATE_PAGE_FUNCTION = <<~JAVASCRIPT
   async function _(predicateBody, polling, timeout, ...args) {

--- a/lib/puppeteer/wait_task.rb
+++ b/lib/puppeteer/wait_task.rb
@@ -106,9 +106,7 @@ class Puppeteer::WaitTask
     @dom_world._wait_tasks.delete(self)
   end
 
-  private async def async_rerun
-    rerun
-  end
+  private define_async_method_for :rerun
 
   WAIT_FOR_PREDICATE_PAGE_FUNCTION = <<~JAVASCRIPT
   async function _(predicateBody, polling, timeout, ...args) {

--- a/spec/puppeteer/async_await_behavior_spec.rb
+++ b/spec/puppeteer/async_await_behavior_spec.rb
@@ -32,4 +32,63 @@ RSpec.describe Puppeteer::AsyncAwaitBehavior do
       expect(res.value!).to eq('my tap!')
     end
   end
+
+  describe 'define_async_method_for' do
+    class Fuga
+      using Puppeteer::AsyncAwaitBehavior
+
+      private def fuga
+        '-> fuga'
+      end
+      define_async_method_for :fuga
+
+      def piyo
+        '-> piyo'
+      end
+      private define_async_method_for :piyo
+    end
+
+    it 'defined async method wrapped with Concurrent::Promises::Future' do
+      instance = Fuga.new
+      expect(instance.async_fuga).to be_a(Concurrent::Promises::Future)
+      expect(instance.async_fuga.value!).to eq('-> fuga')
+    end
+
+    it 'can be used with private' do
+      expect(Fuga.private_method_defined?(:async_piyo)).to eq(true)
+      expect(Fuga.method_defined?(:async_piyo)).to eq(false)
+    end
+
+    it 'raises exception when async method is already defined' do
+      expect {
+        class Ex
+          using Puppeteer::AsyncAwaitBehavior
+
+          private def async_ex
+            "async ex"
+          end
+
+          def ex
+            "ex"
+          end
+          define_async_method_for :ex
+        end
+      }.to raise_error(ArgumentError)
+
+      expect {
+        class Ex
+          using Puppeteer::AsyncAwaitBehavior
+
+          def async_ex
+            "async ex"
+          end
+
+          def ex
+            "ex"
+          end
+          define_async_method_for :ex
+        end
+      }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/spec/puppeteer/async_await_behavior_spec.rb
+++ b/spec/puppeteer/async_await_behavior_spec.rb
@@ -1,38 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Puppeteer::AsyncAwaitBehavior do
-  describe 'async' do
-    class Hoge
-      using Puppeteer::AsyncAwaitBehavior
-
-      async def hoge
-        '-> hoge'
-      end
-
-      async def self.hogehoge
-        '=> hogehoge'
-      end
-
-      async def tap
-        'my tap!'
-      end
-    end
-
-    it 'is wrapped with Concurrent::Promises::Future' do
-      res = Hoge.new.hoge
-      expect(res).to be_a(Concurrent::Promises::Future)
-      expect(res.value!).to eq('-> hoge')
-
-      res = Hoge.hogehoge
-      expect(res).to be_a(Concurrent::Promises::Future)
-      expect(res.value!).to eq('=> hogehoge')
-
-      res = Hoge.new.tap
-      expect(res).to be_a(Concurrent::Promises::Future)
-      expect(res.value!).to eq('my tap!')
-    end
-  end
-
   describe 'define_async_method_for' do
     class Fuga
       using Puppeteer::AsyncAwaitBehavior

--- a/spec/puppeteer/concurrent_ruby_utils_spec.rb
+++ b/spec/puppeteer/concurrent_ruby_utils_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Puppeteer::ConcurrentRubyUtils do
   describe 'await' do
-    class Fuga
+    class AwaitExample
       def fuga1
         await 123
       end
@@ -17,11 +17,11 @@ RSpec.describe Puppeteer::ConcurrentRubyUtils do
     end
 
     it 'return as it is, on no future' do
-      expect(Fuga.new.fuga1).to eq(123)
+      expect(AwaitExample.new.fuga1).to eq(123)
     end
 
     it 'wait until value is set, on future exists' do
-      expect(Fuga.new.fuga2).to eq('hoge')
+      expect(AwaitExample.new.fuga2).to eq('hoge')
     end
   end
 

--- a/spec/puppeteer/define_async_method_spec.rb
+++ b/spec/puppeteer/define_async_method_spec.rb
@@ -27,6 +27,19 @@ RSpec.describe Puppeteer::DefineAsyncMethod do
       expect(DefineAsyncMethodExample.method_defined?(:async_piyo)).to eq(false)
     end
 
+    it 'raises exception when async method name does not start with async_' do
+      expect {
+        class DefineAsyncMethodExample1
+          using Puppeteer::DefineAsyncMethod
+
+          def ex
+            'ex'
+          end
+          define_async_method :ex
+        end
+      }.to raise_error(ArgumentError)
+    end
+
     it 'raises exception when async method is already defined' do
       expect {
         class DefineAsyncMethodExample2

--- a/spec/puppeteer/define_async_method_spec.rb
+++ b/spec/puppeteer/define_async_method_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-RSpec.describe Puppeteer::AsyncAwaitBehavior do
+RSpec.describe Puppeteer::DefineAsyncMethod do
   describe 'define_async_method_for' do
-    class Fuga
-      using Puppeteer::AsyncAwaitBehavior
+    class DefineAsyncMethodExample
+      using Puppeteer::DefineAsyncMethod
 
       private def fuga
         '-> fuga'
@@ -17,20 +17,20 @@ RSpec.describe Puppeteer::AsyncAwaitBehavior do
     end
 
     it 'defined async method wrapped with Concurrent::Promises::Future' do
-      instance = Fuga.new
+      instance = DefineAsyncMethodExample.new
       expect(instance.async_fuga).to be_a(Concurrent::Promises::Future)
       expect(instance.async_fuga.value!).to eq('-> fuga')
     end
 
     it 'can be used with private' do
-      expect(Fuga.private_method_defined?(:async_piyo)).to eq(true)
-      expect(Fuga.method_defined?(:async_piyo)).to eq(false)
+      expect(DefineAsyncMethodExample.private_method_defined?(:async_piyo)).to eq(true)
+      expect(DefineAsyncMethodExample.method_defined?(:async_piyo)).to eq(false)
     end
 
     it 'raises exception when async method is already defined' do
       expect {
-        class Ex
-          using Puppeteer::AsyncAwaitBehavior
+        class DefineAsyncMethodExample2
+          using Puppeteer::DefineAsyncMethod
 
           private def async_ex
             "async ex"
@@ -44,8 +44,8 @@ RSpec.describe Puppeteer::AsyncAwaitBehavior do
       }.to raise_error(ArgumentError)
 
       expect {
-        class Ex
-          using Puppeteer::AsyncAwaitBehavior
+        class DefineAsyncMethodExample3
+          using Puppeteer::DefineAsyncMethod
 
           def async_ex
             "async ex"

--- a/spec/puppeteer/define_async_method_spec.rb
+++ b/spec/puppeteer/define_async_method_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Puppeteer::DefineAsyncMethod do
       private def fuga
         '-> fuga'
       end
-      define_async_method_for :fuga
+      define_async_method :async_fuga
 
       def piyo
         '-> piyo'
       end
-      private define_async_method_for :piyo
+      private define_async_method :async_piyo
     end
 
     it 'defined async method wrapped with Concurrent::Promises::Future' do
@@ -39,7 +39,7 @@ RSpec.describe Puppeteer::DefineAsyncMethod do
           def ex
             "ex"
           end
-          define_async_method_for :ex
+          define_async_method :async_ex
         end
       }.to raise_error(ArgumentError)
 
@@ -54,7 +54,7 @@ RSpec.describe Puppeteer::DefineAsyncMethod do
           def ex
             "ex"
           end
-          define_async_method_for :ex
+          define_async_method :async_ex
         end
       }.to raise_error(ArgumentError)
     end


### PR DESCRIPTION
`async def ...` are boilerplate codes. Replace it with `define_async_method`

### before

```
def click
  ...
end

async def async_click
  click
end
```

### after

```
def click
  ...
end

define_async_method :async_click
```