### PR TITLE
bump rubocop to 0.89

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -146,17 +146,47 @@ Lint/AmbiguousOperator:
 Lint/AmbiguousRegexpLiteral:
   Enabled: true
 
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
 Lint/ErbNewArguments:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/RedundantStringCoercion:
   Enabled: true
 
 # Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
 Lint/RequireParentheses:
   Enabled: true
 
+Lint/SelfAssignment:
+  Enabled: true
+
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/RedundantStringCoercion:
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
   Enabled: true
 
 Lint/UriEscapeUnescape:
@@ -165,14 +195,17 @@ Lint/UriEscapeUnescape:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/DeprecatedClassMethods:
+Style/ParenthesesAroundCondition:
   Enabled: true
 
-Style/ParenthesesAroundCondition:
+Style/ExplicitBlockArgument:
   Enabled: true
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/GlobalStdStream:
+  Enabled: true
 
 Style/HashEachMethods:
   Enabled: true
@@ -197,6 +230,9 @@ Style/RedundantReturn:
 Style/Semicolon:
   Enabled: true
   AllowAsExpressionSeparator: true
+
+Style/StringConcatenation:
+  Enabled: true
 
 # Prefer Foo.method over Foo::method
 Style/ColonMethodCall:

--- a/puppeteer-ruby.gemspec
+++ b/puppeteer-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter' # for CircleCI.
-  spec.add_development_dependency 'rubocop', '~> 0.86.0'
+  spec.add_development_dependency 'rubocop', '~> 0.89.0'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
RuboCop 0.89 introduces many useful cops
https://github.com/rubocop-hq/rubocop/releases/tag/v0.89.0

I want to use 

* Style/ExplicitBlockArgument
* Style/StringConcatenation

and so on...