### PR TITLE
add feature: keyboard with block

### DIFF
--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -266,7 +266,13 @@ class Puppeteer::Page
     @frame_manager.main_frame
   end
 
-  attr_reader :keyboard, :touch_screen, :coverage, :accessibility
+  attr_reader :touch_screen, :coverage, :accessibility
+
+  def keyboard(&block)
+    @keyboard.instance_eval(&block) unless block.nil?
+
+    @keyboard
+  end
 
   def frames
     @frame_manager.frames

--- a/spec/integration/keyboard_spec.rb
+++ b/spec/integration/keyboard_spec.rb
@@ -389,4 +389,32 @@ RSpec.describe Puppeteer::Keyboard do
       expect(meta_key).to eq(true)
     end
   end
+
+  describe 'block' do
+    before {
+      page.content = '<html><body><input id="editor" type="text" /></body></html>'
+    }
+
+    it 'can use press, send_text with block' do
+      page.click('input')
+      page.keyboard {
+        type_text '123456789'
+        down 'Shift'
+        5.times { press 'ArrowLeft' }
+        up 'Shift'
+        send_character 'a'
+      }
+      expect(page.S('input').evaluate('(el) => el.value')).to eq('1234a')
+    end
+
+    it 'can use press, send_text without block' do
+      page.click('input')
+      page.keyboard.type_text '123456789'
+      page.keyboard.down 'Shift'
+      5.times { page.keyboard.press 'ArrowLeft' }
+      page.keyboard.up 'Shift'
+      page.keyboard.send_character 'a'
+      expect(page.S('input').evaluate('(el) => el.value')).to eq('1234a')
+    end
+  end
 end


### PR DESCRIPTION
REMARK: This feature is NOT originated from JS version of puppeteer. Available only in puppeteer-ruby.

It would be better if we can describe sequential operations with keyboard block like below:

```ruby
      page.click('input')
      page.keyboard {
        type_text '123456789'
        down 'Shift'
        5.times { press 'ArrowLeft' }
        up 'Shift'
        send_character 'a'
      }
```

rather than

```ruby
      page.click('input')
      page.keyboard.type_text '123456789'
      page.keyboard.down 'Shift'
      5.times { page.keyboard.press 'ArrowLeft' }
      page.keyboard.up 'Shift'
      page.keyboard.send_character 'a'
```