### PR TITLE
Bump rubocop 0.90

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          rubocop_version: 0.86.0
+          rubocop_version: 0.90.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,9 @@ Layout/EndAlignment:
 Layout/EmptyLineAfterMagicComment:
   Enabled: true
 
+Layout/EmptyLineAfterMultilineCondition:
+  Enabled: true
+
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
   EnforcedStyle: only_before
@@ -102,6 +105,10 @@ Layout/SpaceBeforeComment:
 Layout/SpaceBeforeFirstArg:
   Enabled: true
 
+Style/ClassMethodsDefinitions:
+  Enabled: true
+  EnforcedStyle: def_self
+
 Style/DefWithParentheses:
   Enabled: true
 
@@ -110,6 +117,12 @@ Style/MethodDefParentheses:
   Enabled: true
 
 Style/RedundantFreeze:
+  Enabled: true
+
+Style/RedundantSelf:
+  Enabled: true
+
+Style/RedundantSelfAssignment:
   Enabled: true
 
 # Use `foo {}` not `foo{}`.
@@ -162,9 +175,6 @@ Lint/EmptyConditionalBody:
   Enabled: true
 
 Lint/FloatComparison:
-  Enabled: true
-
-Lint/MissingSuper:
   Enabled: true
 
 Lint/OutOfRangeRegexpRef:

--- a/lib/puppeteer.rb
+++ b/lib/puppeteer.rb
@@ -53,18 +53,14 @@ require 'puppeteer/element_handle'
 
 # ref: https://github.com/puppeteer/puppeteer/blob/master/lib/Puppeteer.js
 class Puppeteer
-  class << self
-    def method_missing(method, *args, **kwargs, &block)
-      instance.send(method, *args, **kwargs, &block)
-    end
+  def self.method_missing(method, *args, **kwargs, &block)
+    @puppeteer ||= Puppeteer.new(
+      project_root: __dir__,
+      preferred_revision: '706915',
+      is_puppeteer_core: true,
+    )
 
-    def instance
-      @instance ||= Puppeteer.new(
-        project_root: __dir__,
-        preferred_revision: '706915',
-        is_puppeteer_core: true,
-      )
-    end
+    @puppeteer.send(method, *args, **kwargs, &block)
   end
 
   # @param project_root [String]

--- a/lib/puppeteer/debug_print.rb
+++ b/lib/puppeteer/debug_print.rb
@@ -3,7 +3,7 @@ require 'logger'
 module Puppeteer::DebugPrint
   if Puppeteer.env.debug?
     def debug_puts(*args, **kwargs)
-      @__debug_logger ||= Logger.new(STDOUT)
+      @__debug_logger ||= Logger.new($stdout)
       @__debug_logger.debug(*args, **kwargs)
     end
 

--- a/lib/puppeteer/define_async_method.rb
+++ b/lib/puppeteer/define_async_method.rb
@@ -14,7 +14,7 @@ module Puppeteer::DefineAsyncMethod
         Concurrent::Promises.future do
           original_method.bind(self).call(*args)
         rescue => err
-          Logger.new(STDERR).warn(err)
+          Logger.new($stderr).warn(err)
           raise err
         end
       end

--- a/puppeteer-ruby.gemspec
+++ b/puppeteer-ruby.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec_junit_formatter' # for CircleCI.
-  spec.add_development_dependency 'rubocop', '~> 0.89.0'
+  spec.add_development_dependency 'rubocop', '~> 0.90.0'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'sinatra'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
* Introduced some usefule Cops, such as EmptyLineAfterMultilineCondition, ClassMethodsDefinitions, RedundantSelfAssignment
* Removed Lint/MissingSuper, because it is often bring false-positive comments.