### PR TITLE
add Firefox support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,8 @@ jobs:
       - run:
           name: rspec
           command: |
-            DEBUG=1 PUPPETEER_PRODUCT=firefox \
-            PUPPETEER_EXECUTABLE_PATH=${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/firefox/firefox \
+            DEBUG=1 PUPPETEER_PRODUCT_RSPEC=firefox \
+            PUPPETEER_EXECUTABLE_PATH_RSPEC=${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/firefox/firefox \
             bundle exec rspec --profile 10 \
               --format RspecJunitFormatter \
               --out test_results/rspec.xml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   rspec:
     docker:
-      - image: circleci/ruby:2.6.3-stretch-node-browsers
+      - image: circleci/ruby:2.6.6-buster-node-browsers
     executor: ruby/default
     steps:
       - checkout
@@ -17,6 +17,28 @@ jobs:
               --format RspecJunitFormatter \
               --out test_results/rspec.xml \
               --format documentation
+
+  rspec_firefox:
+    docker:
+      - image: circleci/ruby:2.6.6-buster-node-browsers
+    executor: ruby/default
+    steps:
+      - checkout
+      - ruby/bundle-install
+      - run:
+          name: install firefox-nightly
+          command: |
+            wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+            tar xf nightly.tar.bz2
+      - run:
+          name: rspec
+          command: |
+            DEBUG=1 PUPPETEER_PRODUCT=firefox \
+            PUPPETEER_EXECUTABLE_PATH=${CIRCLE_WORKING_DIRECTORY/#\~/$HOME}/firefox/firefox \
+            bundle exec rspec --profile 10 \
+              --format RspecJunitFormatter \
+              --out test_results/rspec.xml \
+              --format documentation spec/integration/
 
   deploy:
     docker:
@@ -49,6 +71,7 @@ workflows:
   ci:
     jobs:
       - rspec
+      - rspec_firefox
   rubygems-deploy:
     jobs:
       - deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM circleci/ruby:2.6.6-buster-node-browsers
+
+USER root
+
+RUN wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US" \
+    && tar xf nightly.tar.bz2 \
+    && ln -s $(pwd)/firefox/firefox /usr/bin/firefox
+
+USER circleci

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3"
+services:
+  chrome:
+    tty: true
+    stdin_open: true
+    build: .
+    environment:
+      BUNDLE_PATH: /usr/local/bundle
+      DEBUG: 1
+      CI: 1
+    volumes:
+      - .:/puppeteer-ruby
+      - bundle-data:/usr/local/bundle
+    working_dir: /puppeteer-ruby
+    command: bundle exec rspec
+
+  firefox:
+    tty: true
+    stdin_open: true
+    build: .
+    environment:
+      BUNDLE_PATH: /usr/local/bundle
+      PUPPETEER_PRODUCT_RSPEC: firefox
+      DEBUG: 1
+      CI: 1
+    volumes:
+      - .:/puppeteer-ruby
+      - bundle-data:/usr/local/bundle
+    working_dir: /puppeteer-ruby
+    command: bundle exec rspec spec/integration/
+
+volumes:
+  bundle-data:
+    driver: local

--- a/lib/puppeteer/browser_runner.rb
+++ b/lib/puppeteer/browser_runner.rb
@@ -156,6 +156,6 @@ class Puppeteer::BrowserRunner
       end
     end
   rescue Timeout::Error
-    raise Puppeteer::TimeoutError.new("Timed out after #{timeout} ms while trying to connect to the browser! Only Chrome at revision r#{preferredRevision} is guaranteed to work.")
+    raise Puppeteer::TimeoutError.new("Timed out after #{timeout} ms while trying to connect to the browser! Only Chrome at revision r#{preferred_revision} is guaranteed to work.")
   end
 end

--- a/lib/puppeteer/env.rb
+++ b/lib/puppeteer/env.rb
@@ -10,6 +10,11 @@ class Puppeteer::Env
     ['1', 'true'].include?(ENV['CI'].to_s)
   end
 
+  # check if running on macOS
+  def darwin?
+    RUBY_PLATFORM.include?('darwin')
+  end
+
   # @return [String|NilClass] chrome, firefox, nil
   def product
     (%w(chrome firefox) & [ENV['PUPPETEER_PRODUCT']]).first

--- a/lib/puppeteer/env.rb
+++ b/lib/puppeteer/env.rb
@@ -14,6 +14,14 @@ class Puppeteer::Env
   def product
     (%w(chrome firefox) & [ENV['PUPPETEER_PRODUCT']]).first
   end
+
+  def chrome?
+    product == 'chrome'
+  end
+
+  def firefox?
+    product == 'firefox'
+  end
 end
 
 class Puppeteer

--- a/lib/puppeteer/env.rb
+++ b/lib/puppeteer/env.rb
@@ -14,19 +14,6 @@ class Puppeteer::Env
   def darwin?
     RUBY_PLATFORM.include?('darwin')
   end
-
-  # @return [String|NilClass] chrome, firefox, nil
-  def product
-    (%w(chrome firefox) & [ENV['PUPPETEER_PRODUCT']]).first
-  end
-
-  def chrome?
-    product == 'chrome'
-  end
-
-  def firefox?
-    product == 'firefox'
-  end
 end
 
 class Puppeteer

--- a/lib/puppeteer/env.rb
+++ b/lib/puppeteer/env.rb
@@ -9,6 +9,11 @@ class Puppeteer::Env
   def ci?
     ['1', 'true'].include?(ENV['CI'].to_s)
   end
+
+  # @return [String|NilClass] chrome, firefox, nil
+  def product
+    (%w(chrome firefox) & [ENV['PUPPETEER_PRODUCT']]).first
+  end
 end
 
 class Puppeteer

--- a/lib/puppeteer/launcher.rb
+++ b/lib/puppeteer/launcher.rb
@@ -2,6 +2,7 @@ require_relative './launcher/base'
 require_relative './launcher/browser_options'
 require_relative './launcher/chrome'
 require_relative './launcher/chrome_arg_options'
+require_relative './launcher/firefox'
 require_relative './launcher/launch_options'
 
 # https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts
@@ -9,10 +10,19 @@ module Puppeteer::Launcher
   # @param project_root [String]
   # @param prefereed_revision [String]
   # @param is_puppeteer_core [String]
-  # @param product [String] 'chrome' or 'firefox' (not implemented yet)
+  # @param product [String] 'chrome' or 'firefox'
   # @return [Puppeteer::Launcher::Chrome]
   module_function def new(project_root:, preferred_revision:, is_puppeteer_core:, product:)
+    unless is_puppeteer_core
+      product ||= ENV['PUPPETEER_PRODUCT']
+    end
+
     if product == 'firefox'
+      return Firefox.new(
+        project_root: project_root,
+        preferred_revision: preferred_revision,
+        is_puppeteer_core: is_puppeteer_core,
+      )
       raise NotImplementedError.new('FirefoxLauncher is not implemented yet.')
     end
 

--- a/lib/puppeteer/launcher.rb
+++ b/lib/puppeteer/launcher.rb
@@ -14,7 +14,7 @@ module Puppeteer::Launcher
   # @return [Puppeteer::Launcher::Chrome]
   module_function def new(project_root:, preferred_revision:, is_puppeteer_core:, product:)
     unless is_puppeteer_core
-      product ||= ENV['PUPPETEER_PRODUCT']
+      product ||= Puppeteer.env.product
     end
 
     if product == 'firefox'

--- a/lib/puppeteer/launcher.rb
+++ b/lib/puppeteer/launcher.rb
@@ -14,7 +14,7 @@ module Puppeteer::Launcher
   # @return [Puppeteer::Launcher::Chrome]
   module_function def new(project_root:, preferred_revision:, is_puppeteer_core:, product:)
     unless is_puppeteer_core
-      product ||= Puppeteer.env.product
+      product ||= ENV['PUPPETEER_PRODUCT']
     end
 
     if product == 'firefox'

--- a/lib/puppeteer/launcher/base.rb
+++ b/lib/puppeteer/launcher/base.rb
@@ -25,7 +25,7 @@ module Puppeteer::Launcher
       end
 
       # temporal logic.
-      if RUBY_PLATFORM.include?('darwin') # MacOS
+      if Puppeteer.env.darwin?
         case self
         when Chrome
           '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'

--- a/lib/puppeteer/launcher/base.rb
+++ b/lib/puppeteer/launcher/base.rb
@@ -20,15 +20,25 @@ module Puppeteer::Launcher
           return executable_path
         end
         raise ExecutablePathNotFound.new(
-          "Tried to use PUPPETEER_EXECUTABLE_PATH env variable to launch browser but did not find any executable at: #{executablePath}",
+          "Tried to use PUPPETEER_EXECUTABLE_PATH env variable to launch browser but did not find any executable at: #{executable_path}",
         )
       end
 
       # temporal logic.
       if RUBY_PLATFORM.include?('darwin') # MacOS
-        '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        case self
+        when Chrome
+          '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        when Firefox
+          '/Applications/Firefox Nightly.app/Contents/MacOS/firefox'
+        end
       else
-        '/usr/bin/google-chrome'
+        case self
+        when Chrome
+          '/usr/bin/google-chrome'
+        when Firefox
+          '/usr/bin/firefox'
+        end
       end
 
       # const browserFetcher = new BrowserFetcher(launcher._projectRoot);

--- a/lib/puppeteer/launcher/chrome.rb
+++ b/lib/puppeteer/launcher/chrome.rb
@@ -34,7 +34,7 @@ module Puppeteer::Launcher
 
       temporary_user_data_dir = nil
       if chrome_arguments.none? { |arg| arg.start_with?('--user-data-dir') }
-        temporary_user_data_dir = Dir.mktmpdir('puppeteer_dev_profile-')
+        temporary_user_data_dir = Dir.mktmpdir('puppeteer_dev_chrome_profile-')
         chrome_arguments << "--user-data-dir=#{temporary_user_data_dir}"
       end
 

--- a/lib/puppeteer/launcher/firefox.rb
+++ b/lib/puppeteer/launcher/firefox.rb
@@ -1,0 +1,392 @@
+require 'tmpdir'
+
+# https://github.com/puppeteer/puppeteer/blob/main/src/node/Launcher.ts
+module Puppeteer::Launcher
+  class Firefox < Base
+    # @param {!(Launcher.LaunchOptions & Launcher.ChromeArgOptions & Launcher.BrowserOptions)=} options
+    # @return {!Promise<!Browser>}
+    def launch(options = {})
+      @chrome_arg_options = ChromeArgOptions.new(options)
+      @launch_options = LaunchOptions.new(options)
+      @browser_options = BrowserOptions.new(options)
+
+      firefox_arguments =
+        if !@launch_options.ignore_default_args
+          default_args.to_a
+        elsif @launch_options.ignore_default_args.is_a?(Enumerable)
+          default_args.reject do |arg|
+            @launch_options.ignore_default_args.include?(arg)
+          end.to_a
+        else
+          @chrome_arg_options.args.dup
+        end
+
+      if firefox_arguments.none? { |arg| arg.start_with?('--remote-debugging-') }
+        firefox_arguments << '--remote-debugging-port=0'
+      end
+
+      temporary_user_data_dir = nil
+      if firefox_arguments.none? { |arg| arg.start_with?('--profile') || arg.start_with?('-profile') }
+        temporary_user_data_dir = create_profile
+        firefox_arguments << "--profile"
+        firefox_arguments << temporary_user_data_dir
+      end
+
+      firefox_executable = @launch_options.executable_path || resolve_executable_path
+      runner = Puppeteer::BrowserRunner.new(firefox_executable, firefox_arguments, temporary_user_data_dir)
+      runner.start(
+        handle_SIGHUP: @launch_options.handle_SIGHUP?,
+        handle_SIGTERM: @launch_options.handle_SIGTERM?,
+        handle_SIGINT: @launch_options.handle_SIGINT?,
+        dumpio: @launch_options.dumpio?,
+        env: @launch_options.env,
+        pipe: @launch_options.pipe?,
+      )
+
+      begin
+        connection = runner.setup_connection(
+          use_pipe: @launch_options.pipe?,
+          timeout: @launch_options.timeout,
+          slow_mo: @browser_options.slow_mo,
+          preferred_revision: @preferred_revision,
+        )
+
+        browser = Puppeteer::Browser.create(
+          connection: connection,
+          context_ids: [],
+          ignore_https_errors: @browser_options.ignore_https_errors?,
+          default_viewport: @browser_options.default_viewport,
+          process: runner.proc,
+          close_callback: -> { runner.close },
+        )
+
+        browser.wait_for_target(predicate: ->(target) { target.type == 'page' })
+
+        browser
+      rescue
+        runner.kill
+        raise
+      end
+    end
+
+    # @return [Puppeteer::Browser]
+    def connect(options = {})
+      @browser_options = BrowserOptions.new(options)
+      browser_ws_endpoint = options[:browser_ws_endpoint]
+      browser_url = options[:browser_url]
+      transport = options[:transport]
+
+      connection =
+        if browser_ws_endpoint && browser_url.nil? && transport.nil?
+          connect_with_browser_ws_endpoint(browser_ws_endpoint)
+        elsif browser_ws_endpoint.nil? && browser_url && transport.nil?
+          connect_with_browser_url(browser_url)
+        elsif browser_ws_endpoint.nil? && browser_url.nil? && transport
+          connect_with_transport(transport)
+        else
+          raise ArgumentError.new("Exactly one of browserWSEndpoint, browserURL or transport must be passed to puppeteer.connect")
+        end
+
+      result = connection.send_message('Target.getBrowserContexts')
+      browser_context_ids = result['browserContextIds']
+
+      Puppeteer::Browser.create(
+        connection: connection,
+        context_ids: browser_context_ids,
+        ignore_https_errors: @browser_options.ignore_https_errors?,
+        default_viewport: @browser_options.default_viewport,
+        process: nil,
+        close_callback: -> { connection.send_message('Browser.close') },
+      )
+    end
+
+    # @return [Puppeteer::Connection]
+    private def connect_with_browser_ws_endpoint(browser_ws_endpoint)
+      transport = Puppeteer::WebSocketTransport.create(browser_ws_endpoint)
+      Puppeteer::Connection.new(browser_ws_endpoint, transport, @browser_options.slow_mo)
+    end
+
+    # @return [Puppeteer::Connection]
+    private def connect_with_browser_url(browser_url)
+      require 'net/http'
+      uri = URI(browser_url)
+      uri.path = '/json/version'
+      response_body = Net::HTTP.get(uri)
+      json = JSON.parse(response_body)
+      connection_url = json['webSocketDebuggerUrl']
+      connect_with_browser_ws_endpoint(connection_url)
+    end
+
+    # @return [Puppeteer::Connection]
+    private def connect_with_transport(transport)
+      Puppeteer::Connection.new('', transport, @browser_options.slow_mo)
+    end
+
+    # @return {string}
+    def executable_path
+      resolve_executable_path
+    end
+
+    private def product
+      'firefox'
+    end
+
+    class DefaultArgs
+      include Enumerable
+
+      # @param options [Launcher::ChromeArgOptions]
+      def initialize(chrome_arg_options)
+        firefox_arguments = ['--no-remote', '--foreground']
+
+        # if (os.platform().startsWith('win')) {
+        #   firefoxArguments.push('--wait-for-browser');
+        # }
+
+        if chrome_arg_options.user_data_dir
+          firefox_arguments << "--profile"
+          firefox_arguments << chrome_arg_options.user_data_dir
+        end
+
+        if chrome_arg_options.headless?
+          firefox_arguments << '--headless'
+        end
+
+        if chrome_arg_options.devtools?
+          firefox_arguments << '--devtools'
+        end
+
+        if chrome_arg_options.args.all? { |arg| arg.start_with?('-') }
+          firefox_arguments << 'about:blank'
+        end
+
+        firefox_arguments.concat(chrome_arg_options.args)
+
+        @firefox_arguments = firefox_arguments
+      end
+
+      def each(&block)
+        @firefox_arguments.each do |opt|
+          block.call(opt)
+        end
+      end
+    end
+
+    # @return [DefaultArgs]
+    def default_args(options = nil)
+      if options.nil?
+        @default_args ||= DefaultArgs.new(@chrome_arg_options)
+      else
+        DefaultArgs.new(ChromeArgOptions.new(options))
+      end
+    end
+
+    private def create_profile(extra_prefs = {})
+      Dir.mktmpdir('puppeteer_dev_firefox_profile-').tap do |profile_path|
+        server = 'dummy.test'
+        default_preferences = {
+          # Make sure Shield doesn't hit the network.
+          'app.normandy.api_url': '',
+          # Disable Firefox old build background check
+          'app.update.checkInstallTime': false,
+          # Disable automatically upgrading Firefox
+          'app.update.disabledForTesting': true,
+
+          # Increase the APZ content response timeout to 1 minute
+          'apz.content_response_timeout': 60000,
+
+          # Prevent various error message on the console
+          # jest-puppeteer asserts that no error message is emitted by the console
+          'browser.contentblocking.features.standard': '-tp,tpPrivate,cookieBehavior0,-cm,-fp',
+
+          # Enable the dump function: which sends messages to the system
+          # console
+          # https://bugzilla.mozilla.org/show_bug.cgi?id=1543115
+          'browser.dom.window.dump.enabled': true,
+          # Disable topstories
+          'browser.newtabpage.activity-stream.feeds.section.topstories': false,
+          # Always display a blank page
+          'browser.newtabpage.enabled': false,
+          # Background thumbnails in particular cause grief: and disabling
+          # thumbnails in general cannot hurt
+          'browser.pagethumbnails.capturing_disabled': true,
+
+          # Disable safebrowsing components.
+          'browser.safebrowsing.blockedURIs.enabled': false,
+          'browser.safebrowsing.downloads.enabled': false,
+          'browser.safebrowsing.malware.enabled': false,
+          'browser.safebrowsing.passwords.enabled': false,
+          'browser.safebrowsing.phishing.enabled': false,
+
+          # Disable updates to search engines.
+          'browser.search.update': false,
+          # Do not restore the last open set of tabs if the browser has crashed
+          'browser.sessionstore.resume_from_crash': false,
+          # Skip check for default browser on startup
+          'browser.shell.checkDefaultBrowser': false,
+
+          # Disable newtabpage
+          'browser.startup.homepage': 'about:blank',
+          # Do not redirect user when a milstone upgrade of Firefox is detected
+          'browser.startup.homepage_override.mstone': 'ignore',
+          # Start with a blank page about:blank
+          'browser.startup.page': 0,
+
+          # Do not allow background tabs to be zombified on Android: otherwise for
+          # tests that open additional tabs: the test harness tab itself might get
+          # unloaded
+          'browser.tabs.disableBackgroundZombification': false,
+          # Do not warn when closing all other open tabs
+          'browser.tabs.warnOnCloseOtherTabs': false,
+          # Do not warn when multiple tabs will be opened
+          'browser.tabs.warnOnOpen': false,
+
+          # Disable the UI tour.
+          'browser.uitour.enabled': false,
+          # Turn off search suggestions in the location bar so as not to trigger
+          # network connections.
+          'browser.urlbar.suggest.searches': false,
+          # Disable first run splash page on Windows 10
+          'browser.usedOnWindows10.introURL': '',
+          # Do not warn on quitting Firefox
+          'browser.warnOnQuit': false,
+
+          # Do not show datareporting policy notifications which can
+          # interfere with tests
+          'datareporting.healthreport.about.reportUrl': "http://#{server}/dummy/abouthealthreport/",
+          'datareporting.healthreport.documentServerURI': "http://#{server}/dummy/healthreport/",
+          'datareporting.healthreport.logging.consoleEnabled': false,
+          'datareporting.healthreport.service.enabled': false,
+          'datareporting.healthreport.service.firstRun': false,
+          'datareporting.healthreport.uploadEnabled': false,
+          'datareporting.policy.dataSubmissionEnabled': false,
+          'datareporting.policy.dataSubmissionPolicyAccepted': false,
+          'datareporting.policy.dataSubmissionPolicyBypassNotification': true,
+
+          # DevTools JSONViewer sometimes fails to load dependencies with its require.js.
+          # This doesn't affect Puppeteer but spams console (Bug 1424372)
+          'devtools.jsonview.enabled': false,
+
+          # Disable popup-blocker
+          'dom.disable_open_during_load': false,
+
+          # Enable the support for File object creation in the content process
+          # Required for |Page.setFileInputFiles| protocol method.
+          'dom.file.createInChild': true,
+
+          # Disable the ProcessHangMonitor
+          'dom.ipc.reportProcessHangs': false,
+
+          # Disable slow script dialogues
+          'dom.max_chrome_script_run_time': 0,
+          'dom.max_script_run_time': 0,
+
+          # Only load extensions from the application and user profile
+          # AddonManager.SCOPE_PROFILE + AddonManager.SCOPE_APPLICATION
+          'extensions.autoDisableScopes': 0,
+          'extensions.enabledScopes': 5,
+
+          # Disable metadata caching for installed add-ons by default
+          'extensions.getAddons.cache.enabled': false,
+
+          # Disable installing any distribution extensions or add-ons.
+          'extensions.installDistroAddons': false,
+
+          # Disabled screenshots extension
+          'extensions.screenshots.disabled': true,
+
+          # Turn off extension updates so they do not bother tests
+          'extensions.update.enabled': false,
+
+          # Turn off extension updates so they do not bother tests
+          'extensions.update.notifyUser': false,
+
+          # Make sure opening about:addons will not hit the network
+          'extensions.webservice.discoverURL': "http://#{server}/dummy/discoveryURL",
+
+          # Allow the application to have focus even it runs in the background
+          'focusmanager.testmode': true,
+          # Disable useragent updates
+          'general.useragent.updates.enabled': false,
+          # Always use network provider for geolocation tests so we bypass the
+          # macOS dialog raised by the corelocation provider
+          'geo.provider.testing': true,
+          # Do not scan Wifi
+          'geo.wifi.scan': false,
+          # No hang monitor
+          'hangmonitor.timeout': 0,
+          # Show chrome errors and warnings in the error console
+          'javascript.options.showInConsole': true,
+
+          # Disable download and usage of OpenH264: and Widevine plugins
+          'media.gmp-manager.updateEnabled': false,
+          # Prevent various error message on the console
+          # jest-puppeteer asserts that no error message is emitted by the console
+          'network.cookie.cookieBehavior': 0,
+
+          # Do not prompt for temporary redirects
+          'network.http.prompt-temp-redirect': false,
+
+          # Disable speculative connections so they are not reported as leaking
+          # when they are hanging around
+          'network.http.speculative-parallel-limit': 0,
+
+          # Do not automatically switch between offline and online
+          'network.manage-offline-status': false,
+
+          # Make sure SNTP requests do not hit the network
+          'network.sntp.pools': server,
+
+          # Disable Flash.
+          'plugin.state.flash': 0,
+
+          'privacy.trackingprotection.enabled': false,
+
+          # Enable Remote Agent
+          # https://bugzilla.mozilla.org/show_bug.cgi?id=1544393
+          'remote.enabled': true,
+
+          # Don't do network connections for mitm priming
+          'security.certerrors.mitm.priming.enabled': false,
+          # Local documents have access to all other local documents,
+          # including directory listings
+          'security.fileuri.strict_origin_policy': false,
+          # Do not wait for the notification button security delay
+          'security.notification_enable_delay': 0,
+
+          # Ensure blocklist updates do not hit the network
+          'services.settings.server': "http://#{server}/dummy/blocklist/",
+
+          # Do not automatically fill sign-in forms with known usernames and
+          # passwords
+          'signon.autofillForms': false,
+          # Disable password capture, so that tests that include forms are not
+          # influenced by the presence of the persistent doorhanger notification
+          'signon.rememberSignons': false,
+
+          # Disable first-run welcome page
+          'startup.homepage_welcome_url': 'about:blank',
+
+          # Disable first-run welcome page
+          'startup.homepage_welcome_url.additional': '',
+
+          # Disable browser animations (tabs, fullscreen, sliding alerts)
+          'toolkit.cosmeticAnimations.enabled': false,
+
+          # We want to collect telemetry, but we don't want to send in the results
+          'toolkit.telemetry.server': "https://#{server}/dummy/telemetry/",
+          # Prevent starting into safe mode after application crashes
+          'toolkit.startup.max_resumed_crashes': -1,
+        }
+
+        preferences = default_preferences.merge(extra_prefs)
+
+        File.open(File.join(profile_path, 'user.js'), 'w') do |f|
+          preferences.each do |key, value|
+            f.write("user_pref(#{JSON.generate(key)}, #{JSON.generate(value)});\n")
+          end
+        end
+        IO.write(File.join(profile_path, 'prefs.js'), "")
+      end
+    end
+  end
+end

--- a/spec/integration/browser_context_spec.rb
+++ b/spec/integration/browser_context_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Puppeteer::BrowserContext, puppeteer: :browser do
       expect(browser.pages.length).to eq(1)
     end
 
-    it 'window.open should use parent tab context' do
+    it_fails_firefox 'window.open should use parent tab context' do
       context = browser.create_incognito_browser_context
       page = context.new_page
       page.goto('about:blank')
@@ -59,7 +59,7 @@ RSpec.describe Puppeteer::BrowserContext, puppeteer: :browser do
       end
     end
 
-    it 'should fire target events' do
+    it_fails_firefox 'should fire target events' do
       context = browser.create_incognito_browser_context
       events = []
       context.on('targetcreated') do |target|
@@ -92,7 +92,7 @@ RSpec.describe Puppeteer::BrowserContext, puppeteer: :browser do
       end
     end
 
-    it 'should wait for a target' do
+    it_fails_firefox 'should wait for a target' do
       context = browser.create_incognito_browser_context
       resolved = false
       target_promise = context.async_wait_for_target(predicate: -> (target) { target.url == 'http://127.0.0.1:4567/test' })
@@ -160,7 +160,7 @@ RSpec.describe Puppeteer::BrowserContext, puppeteer: :browser do
       expect(browser.browser_contexts.length).to eq(1)
     end
 
-    it 'should work across sessions' do
+    it_fails_firefox 'should work across sessions' do
       expect(browser.browser_contexts.length).to eq(1)
       context = browser.create_incognito_browser_context
       expect(browser.browser_contexts.length).to eq(2)

--- a/spec/integration/browser_context_spec.rb
+++ b/spec/integration/browser_context_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Puppeteer::BrowserContext, puppeteer: :browser do
       expect(browser.pages.length).to eq(1)
     end
 
-    it_fails_firefox 'window.open should use parent tab context' do
+    it 'window.open should use parent tab context' do
       context = browser.create_incognito_browser_context
       page = context.new_page
       page.goto('about:blank')

--- a/spec/integration/browser_spec.rb
+++ b/spec/integration/browser_spec.rb
@@ -8,8 +8,14 @@ RSpec.describe Puppeteer::Browser, puppeteer: :browser do
   end
 
   describe 'user_agent' do
-    it 'should include WebKit' do
-      expect(browser.user_agent).to include('WebKit')
+    if Puppeteer.env.firefox?
+      it 'should include Gecko' do
+        expect(browser.user_agent).to include('Gecko')
+      end
+    else
+      it 'should include WebKit' do
+        expect(browser.user_agent).to include('WebKit')
+      end
     end
   end
 

--- a/spec/integration/click_spec.rb
+++ b/spec/integration/click_spec.rb
@@ -260,7 +260,7 @@ RSpec.describe Puppeteer::Page do
       page.goto("http://127.0.0.1:4567/offscreenbuttons")
     }
 
-    it_fails_firefox 'should click offscreen buttons' do
+    it 'should click offscreen buttons' do
       11.times do |i|
         # We might've scrolled to click a button - reset to (0, 0).
         page.evaluate('() => window.scrollTo(0, 0)')
@@ -382,7 +382,7 @@ RSpec.describe Puppeteer::Page do
       expect(page.evaluate('() => globalThis.result.check')).to eq(false)
     end
 
-    it_fails_firefox 'should click on checkbox label and toggle' do
+    it 'should click on checkbox label and toggle' do
       expect(page.evaluate('() => globalThis.result.check')).to be_nil
 
       page.click('label[for="agree"]')
@@ -615,7 +615,7 @@ RSpec.describe Puppeteer::Page do
         attach_frame(page, 'button-test', '/button')
       }
 
-      it_fails_firefox 'should click the button inside an iframe' do
+      it 'should click the button inside an iframe' do
         frame = page.frames.last
         frame.S('button').click
         expect(frame.evaluate('() => globalThis.result')).to eq('Clicked')
@@ -635,7 +635,7 @@ RSpec.describe Puppeteer::Page do
         attach_frame(page, 'button-test', '/button')
       }
 
-      it_fails_firefox 'should click the button inside an iframe' do
+      it 'should click the button inside an iframe' do
         frame = page.frames.last
         frame.S('button').click
         expect(frame.evaluate('() => globalThis.result')).to eq('Clicked')

--- a/spec/integration/click_spec.rb
+++ b/spec/integration/click_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Puppeteer::Page do
         page.evaluate('() => delete window.Node')
       }
 
-      it 'should click button' do
+      it_fails_firefox 'should click button' do
         page.click('button')
         expect(page.evaluate('() => globalThis.result')).to eq('Clicked')
       end
@@ -136,7 +136,7 @@ RSpec.describe Puppeteer::Page do
       page.goto("http://127.0.0.1:4567/wrappedlink")
     }
 
-    it 'should click with disabled javascript' do
+    it_fails_firefox 'should click with disabled javascript' do
       await_all(
         page.async_wait_for_navigation,
         page.async_click('a'),
@@ -260,7 +260,7 @@ RSpec.describe Puppeteer::Page do
       page.goto("http://127.0.0.1:4567/offscreenbuttons")
     }
 
-    it 'should click offscreen buttons' do
+    it_fails_firefox 'should click offscreen buttons' do
       11.times do |i|
         # We might've scrolled to click a button - reset to (0, 0).
         page.evaluate('() => window.scrollTo(0, 0)')
@@ -382,7 +382,7 @@ RSpec.describe Puppeteer::Page do
       expect(page.evaluate('() => globalThis.result.check')).to eq(false)
     end
 
-    it 'should click on checkbox label and toggle' do
+    it_fails_firefox 'should click on checkbox label and toggle' do
       expect(page.evaluate('() => globalThis.result.check')).to be_nil
 
       page.click('label[for="agree"]')
@@ -615,7 +615,7 @@ RSpec.describe Puppeteer::Page do
         attach_frame(page, 'button-test', '/button')
       }
 
-      it 'should click the button inside an iframe' do
+      it_fails_firefox 'should click the button inside an iframe' do
         frame = page.frames.last
         frame.S('button').click
         expect(frame.evaluate('() => globalThis.result')).to eq('Clicked')
@@ -635,7 +635,7 @@ RSpec.describe Puppeteer::Page do
         attach_frame(page, 'button-test', '/button')
       }
 
-      it 'should click the button inside an iframe' do
+      it_fails_firefox 'should click the button inside an iframe' do
         frame = page.frames.last
         frame.S('button').click
         expect(frame.evaluate('() => globalThis.result')).to eq('Clicked')

--- a/spec/integration/element_handle_spec.rb
+++ b/spec/integration/element_handle_spec.rb
@@ -57,6 +57,10 @@ RSpec.describe Puppeteer::ElementHandle do
           ::-webkit-scrollbar {
               display: none;
           }
+          html { /* for Firefox */
+            scrollbar-width: none;
+          }
+
           </style>
           HTML
         end
@@ -91,6 +95,9 @@ RSpec.describe Puppeteer::ElementHandle do
           ::-webkit-scrollbar{
               display: none;
           }
+          html { /* for Firefox */
+            scrollbar-width: none;
+          }
           </style>
           <script>
           async function attachFrame(frameId, url) {
@@ -117,6 +124,10 @@ RSpec.describe Puppeteer::ElementHandle do
           body iframe {
               flex-grow: 1;
               flex-shrink: 1;
+          }
+
+          html { /* for Firefox */
+            scrollbar-width: none;
           }
           </style>
           <iframe src='./frame.html' name='uno'></iframe>

--- a/spec/integration/js_handle_spec.rb
+++ b/spec/integration/js_handle_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Puppeteer::JSHandle do
       expect(json).to eq({ 'foo' => 'bar' })
     end
 
-    it 'should not work with dates' do
+    it_fails_firefox 'should not work with dates' do
       date_handle = page.evaluate_handle("() => new Date('2017-09-26T00:00:00.000Z')")
       json = date_handle.json_value
       expect(json).to eq({})
@@ -52,7 +52,11 @@ RSpec.describe Puppeteer::JSHandle do
 
     it 'should throw for circular objects' do
       window_handle = page.evaluate_handle('window')
-      expect { window_handle.json_value }.to raise_error(/Object reference chain is too long/)
+      if Puppeteer.env.chrome?
+        expect { window_handle.json_value }.to raise_error(/Object reference chain is too long/)
+      elsif Puppeteer.env.firefox?
+        expect { window_handle.json_value }.to raise_error(/Object is not serializable/)
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,4 +76,16 @@ RSpec.configure do |config|
   config.include PuppeteerMethods, type: :puppeteer
 end
 
+module ItFailsFirefox
+  def it_fails_firefox(*args, **kwargs, &block)
+    if Puppeteer.env.firefox?
+      xit(*args, **kwargs, &block)
+    else
+      it(*args, **kwargs, &block)
+    end
+  end
+end
+
+RSpec::Core::ExampleGroup.extend(ItFailsFirefox)
+
 require_relative './utils'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,23 @@ end
 
 RSpec::Core::ExampleGroup.extend(SinatraRouting)
 
+module PuppeteerEnvExtension
+  # @return [String] chrome, firefox
+  def product
+    (%w(chrome firefox) & [ENV['PUPPETEER_PRODUCT_RSPEC']]).first || 'chrome'
+  end
+
+  def chrome?
+    product == 'chrome'
+  end
+
+  def firefox?
+    product == 'firefox'
+  end
+end
+
+Puppeteer::Env.include(PuppeteerEnvExtension)
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'
@@ -39,8 +56,8 @@ RSpec.configure do |config|
   end
 
   launch_options = {
-    product: Puppeteer.env.product || 'chrome',
-    executable_path: ENV['PUPPETEER_EXECUTABLE_PATH'],
+    product: Puppeteer.env.product,
+    executable_path: ENV['PUPPETEER_EXECUTABLE_PATH_RSPEC'],
   }.compact
   if Puppeteer.env.debug? && !Puppeteer.env.ci?
     launch_options[:headless] = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,10 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  launch_options = {}
+  launch_options = {
+    product: Puppeteer.env.product || 'chrome',
+    executable_path: ENV['PUPPETEER_EXECUTABLE_PATH'],
+  }.compact
   if Puppeteer.env.debug? && !Puppeteer.env.ci?
     launch_options[:headless] = false
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,9 +53,19 @@ RSpec.configure do |config|
         example.run
       end
     else
-      Puppeteer.launch(**launch_options) do |browser|
-        @puppeteer_page = browser.pages.first || browser.new_page
-        example.run
+      if Puppeteer.env.firefox?
+        Puppeteer.launch(**launch_options) do |browser|
+          # Firefox often fails page.focus by reusing the page with 'browser.pages.first'.
+          # So create new page for each spec.
+          @puppeteer_page = browser.new_page
+          example.run
+          @puppeteer_page.close
+        end
+      else
+        Puppeteer.launch(**launch_options) do |browser|
+          @puppeteer_page = browser.pages.first || new_page
+          example.run
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,7 +89,7 @@ end
 module ItFailsFirefox
   def it_fails_firefox(*args, **kwargs, &block)
     if Puppeteer.env.firefox?
-      xit(*args, **kwargs, &block)
+      pending(*args, **kwargs, &block)
     else
       it(*args, **kwargs, &block)
     end


### PR DESCRIPTION
Now we can enjoy automation with Firefox, by specifying `product: firefox`

```ruby
Puppeteer.launch(headless: false, product: 'firefox') do |browser|
  page = browser.pages.first || browser.new_page
  page.goto('https://www.google.com/')

  page.click("input[name='q']")
  page.keyboard {
    type_text 'puppeteer'
    press 'Enter'
  }

  sleep 10
end
```

![puppteer-firefox](https://user-images.githubusercontent.com/11763113/92302502-af6db180-efa7-11ea-8b5b-70ee7c395890.gif)
