### PR TITLE
show warning in "#future"

### DIFF
--- a/lib/puppeteer/concurrent_ruby_utils.rb
+++ b/lib/puppeteer/concurrent_ruby_utils.rb
@@ -32,7 +32,12 @@ module Puppeteer::ConcurrentRubyUtils
   end
 
   def future(&block)
-    Concurrent::Promises.future(&block)
+    Concurrent::Promises.future do
+      block.call
+    rescue => err
+      Logger.new($stderr).warn(err)
+      raise err
+    end
   end
 
   def resolvable_future(&block)

--- a/spec/puppeteer/concurrent_ruby_utils_spec.rb
+++ b/spec/puppeteer/concurrent_ruby_utils_spec.rb
@@ -66,4 +66,13 @@ RSpec.describe Puppeteer::ConcurrentRubyUtils do
       expect(Time.now - start).to be < 1
     end
   end
+
+  describe 'future' do
+    let(:invalid_future) { future { undefined_variable_is_me } }
+
+    it 'warns error' do
+      expect { invalid_future ; sleep 1 }.to output(include("NameError").and(include("undefined_variable_is_me"))).to_stderr
+      expect { await invalid_future }.to raise_error(NameError)
+    end
+  end
 end


### PR DESCRIPTION
When we use future like `future { hoge }` , it doesn't raise error and nothing is shown in log.
It is hard to detect some mistakes (such as typo).

```
W, [2020-11-14T03:30:27.918673 #12501]  WARN -- : undefined local variable or method `undefined_variable_is_me' for #<RSpec::ExampleGroups::PuppeteerConcurrentRubyUtils::Future:0x00007fe2534a7350> (NameError)
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/rspec-expectations-3.9.0/lib/rspec/matchers.rb:963:in `method_missing'
```

With this PR, error will be shown in STDERR as a warning.