### PR TITLE
Revert deletion of workaround for unordered SEND/RECV 

### DIFF
--- a/lib/puppeteer/cdp_session.rb
+++ b/lib/puppeteer/cdp_session.rb
@@ -52,8 +52,10 @@ class Puppeteer::CDPSession
       else
         debug_puts "unknown id: #{id}. Store it into pending message"
 
-        # RECV is often notified before SEND.
-        # Wait about 10 frames before throwing an error.
+        # RECV is sometimes notified before SEND.
+        # Something is wrong (thread-unsafe)...
+        # As a Workaround,
+        # wait about 10 frames before throwing an error.
         message_id = message['id']
         @pending_messages[message_id] = message
         Concurrent::Promises.schedule(0.16, message_id) do |id|

--- a/lib/puppeteer/cdp_session.rb
+++ b/lib/puppeteer/cdp_session.rb
@@ -13,6 +13,7 @@ class Puppeteer::CDPSession
     @connection = connection
     @target_type = target_type
     @session_id = session_id
+    @pending_messages = {}
   end
 
   attr_reader :connection
@@ -34,7 +35,12 @@ class Puppeteer::CDPSession
     id = @connection.raw_send(message: { sessionId: @session_id, method: method, params: params })
     promise = resolvable_future
     callback = Puppeteer::Connection::MessageCallback.new(method: method, promise: promise)
-    @callbacks[id] = callback
+    if pending_message = @pending_messages.delete(id)
+      debug_puts "Pending message (id: #{id}) is handled"
+      callback_with_message(callback, pending_message)
+    else
+      @callbacks[id] = callback
+    end
     promise
   end
 
@@ -44,7 +50,17 @@ class Puppeteer::CDPSession
       if callback = @callbacks.delete(message['id'])
         callback_with_message(callback, message)
       else
-        raise Error.new("unknown id: #{id}")
+        debug_puts "unknown id: #{id}. Store it into pending message"
+
+        # RECV is often notified before SEND.
+        # Wait about 10 frames before throwing an error.
+        message_id = message['id']
+        @pending_messages[message_id] = message
+        Concurrent::Promises.schedule(0.16, message_id) do |id|
+          if @pending_messages.delete(id)
+            raise Error.new("unknown id: #{id}")
+          end
+        end
       end
     else
       emit_event(message['method'], message['params'])


### PR DESCRIPTION
After https://github.com/YusukeIwaki/puppeteer-ruby/commit/345a4bf5b52b1397e4945bd0206b8da560391448, workaround logic seemed to be no longer required.
However, the unordered RECV/SEND occasionally happens...

```
D, [2020-11-27T18:57:37.153280 #21053] DEBUG -- : RECV << {"id"=>3, "result"=>{}, "sessionId"=>"3B6890FD90EFCE617B47AE0AA959FBF0"}
W, [2020-11-27T18:57:37.153463 #21053]  WARN -- : undefined local variable or method `id' for #<Puppeteer::CDPSession:0x00007fcc37d14a10> (NameError)
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/cdp_session.rb:47:in `handle_message'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/connection.rb:199:in `handle_message'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/define_async_method.rb:15:in `call'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/define_async_method.rb:15:in `block (2 levels) in define_async_method'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/promises.rb:1582:in `evaluate_to'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/promises.rb:1765:in `block in on_resolvable'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:353:in `run_task'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:342:in `block (3 levels) in create_worker'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:325:in `loop'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:325:in `block (2 levels) in create_worker'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:324:in `catch'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/2.6.0/gems/concurrent-ruby-1.1.6/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:324:in `block in create_worker'
D, [2020-11-27T18:57:37.147072 #21053] DEBUG -- : SEND >> {"sessionId":"3B6890FD90EFCE617B47AE0AA959FBF0","method":"Target.setAutoAttach","params":{"autoAttach":true,"waitForDebuggerOnStart":false,"flatten":true},"id":3}
```

So revert the logic for more stability