### PR TITLE
Suppress Puppeteer::TimeoutError logging

### DIFF
--- a/lib/puppeteer/concurrent_ruby_utils.rb
+++ b/lib/puppeteer/concurrent_ruby_utils.rb
@@ -42,6 +42,9 @@ module Puppeteer::ConcurrentRubyUtils
   def future(*args, &block)
     Concurrent::Promises.future(*args) do |*block_args|
       block.call(*block_args)
+    rescue Puppeteer::TimeoutError
+      # suppress error logging
+      raise
     rescue => err
       Logger.new($stderr).warn(err)
       raise err


### PR DESCRIPTION
Timeout error logs are really annoying. It doesn't imply anything. So suppress it.

| before | after |
|:---:|:---:|
|![image](https://user-images.githubusercontent.com/11763113/102839305-892f2d00-4443-11eb-86fc-746e0484b749.png)|  ![image](https://user-images.githubusercontent.com/11763113/102839371-b67bdb00-4443-11eb-8e57-77a8cf3b2e7d.png) |
