### PR TITLE
Revert "Prevent creating a blank page on Puppeteer.launch(headless: false)"

### DIFF
--- a/lib/puppeteer/launcher/chrome.rb
+++ b/lib/puppeteer/launcher/chrome.rb
@@ -67,9 +67,7 @@ module Puppeteer::Launcher
           close_callback: -> { runner.close },
         )
 
-        unless browser.pages.empty?
-          browser.wait_for_target(predicate: ->(target) { target.type == 'page' })
-        end
+        browser.wait_for_target(predicate: ->(target) { target.type == 'page' })
 
         browser
       rescue
@@ -94,7 +92,7 @@ module Puppeteer::Launcher
           '--disable-default-apps',
           '--disable-dev-shm-usage',
           '--disable-extensions',
-          '--disable-features=Translate',
+          '--disable-features=TranslateUI',
           '--disable-hang-monitor',
           '--disable-ipc-flooding-protection',
           '--disable-popup-blocking',
@@ -129,11 +127,7 @@ module Puppeteer::Launcher
         end
 
         if chrome_arg_options.args.all? { |arg| arg.start_with?('-') }
-          if chrome_arg_options.headless?
-            chrome_arguments << 'about:blank'
-          else
-            chrome_arguments << '--no-startup-window'
-          end
+          chrome_arguments << 'about:blank'
         end
 
         chrome_arguments.concat(chrome_arg_options.args)

--- a/lib/puppeteer/launcher/chrome.rb
+++ b/lib/puppeteer/launcher/chrome.rb
@@ -92,7 +92,7 @@ module Puppeteer::Launcher
           '--disable-default-apps',
           '--disable-dev-shm-usage',
           '--disable-extensions',
-          '--disable-features=TranslateUI',
+          '--disable-features=Translate',
           '--disable-hang-monitor',
           '--disable-ipc-flooding-protection',
           '--disable-popup-blocking',

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -327,63 +327,57 @@ RSpec.describe Puppeteer::Launcher do
     end
   end
 
-  describe 'Puppeteer.launch', puppeteer: :browser do
-    #     let productName;
+#   describe('Puppeteer.launch', function () {
+#     let productName;
 
-    #     before(async () => {
-    #       const { puppeteer } = getTestState();
-    #       productName = puppeteer._productName;
-    #     });
+#     before(async () => {
+#       const { puppeteer } = getTestState();
+#       productName = puppeteer._productName;
+#     });
 
-    #     after(async () => {
-    #       const { puppeteer } = getTestState();
-    #       // @ts-expect-error launcher is a private property that users can't
-    #       // touch, but for testing purposes we need to reset it.
-    #       puppeteer._lazyLauncher = undefined;
-    #       puppeteer._productName = productName;
-    #     });
+#     after(async () => {
+#       const { puppeteer } = getTestState();
+#       // @ts-expect-error launcher is a private property that users can't
+#       // touch, but for testing purposes we need to reset it.
+#       puppeteer._lazyLauncher = undefined;
+#       puppeteer._productName = productName;
+#     });
 
-    #     itOnlyRegularInstall('should be able to launch Chrome', async () => {
-    #       const { puppeteer } = getTestState();
-    #       const browser = await puppeteer.launch({ product: 'chrome' });
-    #       const userAgent = await browser.userAgent();
-    #       await browser.close();
-    #       expect(userAgent).toContain('Chrome');
-    #     });
+#     itOnlyRegularInstall('should be able to launch Chrome', async () => {
+#       const { puppeteer } = getTestState();
+#       const browser = await puppeteer.launch({ product: 'chrome' });
+#       const userAgent = await browser.userAgent();
+#       await browser.close();
+#       expect(userAgent).toContain('Chrome');
+#     });
 
-    #     it('falls back to launching chrome if there is an unknown product but logs a warning', async () => {
-    #       const { puppeteer } = getTestState();
-    #       const consoleStub = sinon.stub(console, 'warn');
-    #       // @ts-expect-error purposeful bad input
-    #       const browser = await puppeteer.launch({ product: 'SO_NOT_A_PRODUCT' });
-    #       const userAgent = await browser.userAgent();
-    #       await browser.close();
-    #       expect(userAgent).toContain('Chrome');
-    #       expect(consoleStub.callCount).toEqual(1);
-    #       expect(consoleStub.firstCall.args).toEqual([
-    #         'Warning: unknown product name SO_NOT_A_PRODUCT. Falling back to chrome.',
-    #       ]);
-    #     });
+#     it('falls back to launching chrome if there is an unknown product but logs a warning', async () => {
+#       const { puppeteer } = getTestState();
+#       const consoleStub = sinon.stub(console, 'warn');
+#       // @ts-expect-error purposeful bad input
+#       const browser = await puppeteer.launch({ product: 'SO_NOT_A_PRODUCT' });
+#       const userAgent = await browser.userAgent();
+#       await browser.close();
+#       expect(userAgent).toContain('Chrome');
+#       expect(consoleStub.callCount).toEqual(1);
+#       expect(consoleStub.firstCall.args).toEqual([
+#         'Warning: unknown product name SO_NOT_A_PRODUCT. Falling back to chrome.',
+#       ]);
+#     });
 
-    #     /* We think there's a bug in the FF Windows launcher, or some
-    #      * combo of that plus it running on CI, but it's hard to track down.
-    #      * See comment here: https://github.com/puppeteer/puppeteer/issues/5673#issuecomment-670141377.
-    #      */
-    #     itFailsWindows('should be able to launch Firefox', async function () {
-    #       this.timeout(FIREFOX_TIMEOUT);
-    #       const { puppeteer } = getTestState();
-    #       const browser = await puppeteer.launch({ product: 'firefox' });
-    #       const userAgent = await browser.userAgent();
-    #       await browser.close();
-    #       expect(userAgent).toContain('Firefox');
-    #     });
-    #   });
-
-    it_fails_firefox 'should not create pages automatically on headful mode' do
-      skip if headless?
-      expect(browser.pages.length).to eq(0)
-    end
-  end
+#     /* We think there's a bug in the FF Windows launcher, or some
+#      * combo of that plus it running on CI, but it's hard to track down.
+#      * See comment here: https://github.com/puppeteer/puppeteer/issues/5673#issuecomment-670141377.
+#      */
+#     itFailsWindows('should be able to launch Firefox', async function () {
+#       this.timeout(FIREFOX_TIMEOUT);
+#       const { puppeteer } = getTestState();
+#       const browser = await puppeteer.launch({ product: 'firefox' });
+#       const userAgent = await browser.userAgent();
+#       await browser.close();
+#       expect(userAgent).toContain('Firefox');
+#     });
+#   });
 
   describe 'Puppeteer.connect', puppeteer: :browser do
     it 'should be able to connect multiple times to the same browser' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,7 +102,7 @@ RSpec.configure do |config|
         end
       else
         Puppeteer.launch(**launch_options) do |browser|
-          @puppeteer_page = browser.pages.first || new_page
+          @puppeteer_page = browser.pages.first || browser.new_page
           example.run
         end
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -102,7 +102,7 @@ RSpec.configure do |config|
         end
       else
         Puppeteer.launch(**launch_options) do |browser|
-          @puppeteer_page = browser.pages.first || browser.new_page
+          @puppeteer_page = browser.pages.first || new_page
           example.run
         end
       end


### PR DESCRIPTION
Reverts YusukeIwaki/puppeteer-ruby#48, refs #47

It seems we can't use Capybara with `--no-startup-window`...