### PR TITLE
Add installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ REMARK: This Gem is NOT production-ready!!
 
 ## Getting Started
 
+### Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'puppeteer-ruby'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install puppeteer-ruby
+
 ### Capture a site
 
 ```ruby


### PR DESCRIPTION
There is a conflicting rubygem that isn't related to this project called `puppeteer`. This adds explicit instructions.

Fixes https://github.com/YusukeIwaki/puppeteer-ruby/issues/49