### PR TITLE
Fix window.opener spec with target=_blank

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
   rspec_chrome_ruby3_0:
     docker:
-      - image: circleci/ruby:3.0.0-rc1-buster-node-browsers
+      - image: circleci/ruby:3.0.0-buster-node-browsers
     <<: *rspec_chrome_job
 
   rspec_firefox:

--- a/spec/integration/page_spec.rb
+++ b/spec/integration/page_spec.rb
@@ -199,6 +199,18 @@ RSpec.describe Puppeteer::Page do
         expect(popup.evaluate("() => !!window.opener")).to eq(false) # was true in Chrome < 88.
       end
 
+      it_fails_firefox 'should work with clicking target=_blank and rel=opener' do
+        page.goto('http://127.0.0.1:4567/')
+        page.content = '<a target=_blank rel=opener href="/hello.html">yo</a>'
+
+        popup_promise = resolvable_future { |f| page.once('popup') { |popup| f.fulfill(popup) } }
+        page.click("a")
+        popup = await popup_promise
+
+        expect(page.evaluate("() => !!window.opener")).to eq(false)
+        expect(popup.evaluate("() => !!window.opener")).to eq(true)
+      end
+
       it_fails_firefox 'should work with fake-clicking target=_blank and rel=noopener' do
         page.goto('http://127.0.0.1:4567/')
         page.content = '<a target=_blank rel=noopener href="/hello.html">yo</a>'

--- a/spec/integration/page_spec.rb
+++ b/spec/integration/page_spec.rb
@@ -196,7 +196,7 @@ RSpec.describe Puppeteer::Page do
         popup = await popup_promise
 
         expect(page.evaluate("() => !!window.opener")).to eq(false)
-        expect(popup.evaluate("() => !!window.opener")).to eq(true)
+        expect(popup.evaluate("() => !!window.opener")).to eq(false) # was true in Chrome < 88.
       end
 
       it_fails_firefox 'should work with fake-clicking target=_blank and rel=noopener' do


### PR DESCRIPTION
`target=_blank` assumes rel=noopener by default in Chrome >= 88
https://www.chromestatus.com/feature/6140064063029248