### PR TITLE
Revert "Remove ugly logic in Connection"

### DIFF
--- a/lib/puppeteer/connection.rb
+++ b/lib/puppeteer/connection.rb
@@ -273,6 +273,16 @@ class Puppeteer::Connection
   def create_session(target_info)
     result = send_message('Target.attachToTarget', targetId: target_info.target_id, flatten: true)
     session_id = result['sessionId']
-    @sessions[session_id]
+
+    # Target.attachedToTarget is often notified after the result of Target.attachToTarget.
+    # D, [2020-04-04T23:04:30.736311 #91875] DEBUG -- : RECV << {"id"=>2, "result"=>{"sessionId"=>"DA002F8A95B04710502CB40D8430B95A"}}
+    # D, [2020-04-04T23:04:30.736649 #91875] DEBUG -- : RECV << {"method"=>"Target.attachedToTarget", "params"=>{"sessionId"=>"DA002F8A95B04710502CB40D8430B95A", "targetInfo"=>{"targetId"=>"EBAB949A7DE63F12CB94268AD3A9976B", "type"=>"page", "title"=>"about:blank", "url"=>"about:blank", "attached"=>true, "browserContextId"=>"46D23767E9B79DD9E589101121F6DADD"}, "waitingForDebugger"=>false}}
+    # So we have to wait for "Target.attachedToTarget" a bit.
+    20.times do
+      if @sessions[session_id]
+        return @sessions[session_id]
+      end
+      sleep 0.1
+    end
   end
 end


### PR DESCRIPTION
CI shows that create_cdp_session is flaky.

https://app.circleci.com/pipelines/github/YusukeIwaki/puppeteer-ruby/468/workflows/44619157-feeb-46fc-a64c-44ba94a2eb98/jobs/1035

We expect the response of `Target.attachToTarget` is notified after `Target.attachedToTarget` as below.

```
D, [2021-03-24T02:31:58.468327 #185] DEBUG -- : SEND >> {"method":"Target.attachToTarget","params":{"targetId":"55C49F240E82162425206714EEF541C0","flatten":true},"id":3}
D, [2021-03-24T02:31:58.472950 #185] DEBUG -- : RECV << {"method"=>"Target.targetInfoChanged", "params"=>{"targetInfo"=>{"targetId"=>"55C49F240E82162425206714EEF541C0", "type"=>"page", "title"=>"about:blank", "url"=>"about:blank", "attached"=>true, "canAccessOpener"=>false, "browserContextId"=>"8A2A380840AA61C4436771D626A7D501"}}}
D, [2021-03-24T02:31:58.477273 #185] DEBUG -- : RECV << {"method"=>"Target.attachedToTarget", "params"=>{"sessionId"=>"D2C4D58365EBE1E32126747DD7F4BA34", "targetInfo"=>{"targetId"=>"55C49F240E82162425206714EEF541C0", "type"=>"page", "title"=>"about:blank", "url"=>"about:blank", "attached"=>true, "canAccessOpener"=>false, "browserContextId"=>"8A2A380840AA61C4436771D626A7D501"}, "waitingForDebugger"=>false}}
D, [2021-03-24T02:31:58.481482 #185] DEBUG -- : RECV << {"id"=>3, "result"=>{"sessionId"=>"D2C4D58365EBE1E32126747DD7F4BA34"}}
```

However sometimes it is handled before `Target.attachedToTarget` in puppeteer-ruby... :(

```
D, [2021-03-24T02:31:57.916096 #184] DEBUG -- : SEND >> {"method":"Target.attachToTarget","params":{"targetId":"8FCED85286A94DA18691FA03A0FBF754","flatten":true},"id":3}
D, [2021-03-24T02:31:57.925768 #184] DEBUG -- : RECV << {"method"=>"Target.targetInfoChanged", "params"=>{"targetInfo"=>{"targetId"=>"8FCED85286A94DA18691FA03A0FBF754", "type"=>"page", "title"=>"about:blank", "url"=>"about:blank", "attached"=>true, "canAccessOpener"=>false, "browserContextId"=>"35DF46B93612D40FE39AC3FBE225E285"}}}
D, [2021-03-24T02:31:57.934569 #184] DEBUG -- : RECV << {"id"=>3, "result"=>{"sessionId"=>"E2CD34604C2BF4D7654A31D676F42EC0"}}
D, [2021-03-24T02:31:57.938448 #184] DEBUG -- : RECV << {"method"=>"Target.attachedToTarget", "params"=>{"sessionId"=>"E2CD34604C2BF4D7654A31D676F42EC0", "targetInfo"=>{"targetId"=>"8FCED85286A94DA18691FA03A0FBF754", "type"=>"page", "title"=>"about:blank", "url"=>"about:blank", "attached"=>true, "canAccessOpener"=>false, "browserContextId"=>"35DF46B93612D40FE39AC3FBE225E285"}, "waitingForDebugger"=>false}}
```