### PR TITLE
Synchronous message handling for improving flaky test failure

### DIFF
--- a/lib/puppeteer/cdp_session.rb
+++ b/lib/puppeteer/cdp_session.rb
@@ -51,7 +51,7 @@ class Puppeteer::CDPSession
         raise Error.new("unknown id: #{message['id']}")
       end
     else
-      future { emit_event(message['method'], message['params']) }
+      emit_event(message['method'], message['params'])
     end
   end
 

--- a/lib/puppeteer/cdp_session.rb
+++ b/lib/puppeteer/cdp_session.rb
@@ -51,7 +51,7 @@ class Puppeteer::CDPSession
         raise Error.new("unknown id: #{message['id']}")
       end
     else
-      emit_event(message['method'], message['params'])
+      future { emit_event(message['method'], message['params']) }
     end
   end
 

--- a/lib/puppeteer/connection.rb
+++ b/lib/puppeteer/connection.rb
@@ -273,16 +273,6 @@ class Puppeteer::Connection
   def create_session(target_info)
     result = send_message('Target.attachToTarget', targetId: target_info.target_id, flatten: true)
     session_id = result['sessionId']
-
-    # Target.attachedToTarget is often notified after the result of Target.attachToTarget.
-    # D, [2020-04-04T23:04:30.736311 #91875] DEBUG -- : RECV << {"id"=>2, "result"=>{"sessionId"=>"DA002F8A95B04710502CB40D8430B95A"}}
-    # D, [2020-04-04T23:04:30.736649 #91875] DEBUG -- : RECV << {"method"=>"Target.attachedToTarget", "params"=>{"sessionId"=>"DA002F8A95B04710502CB40D8430B95A", "targetInfo"=>{"targetId"=>"EBAB949A7DE63F12CB94268AD3A9976B", "type"=>"page", "title"=>"about:blank", "url"=>"about:blank", "attached"=>true, "browserContextId"=>"46D23767E9B79DD9E589101121F6DADD"}, "waitingForDebugger"=>false}}
-    # So we have to wait for "Target.attachedToTarget" a bit.
-    20.times do
-      if @sessions[session_id]
-        return @sessions[session_id]
-      end
-      sleep 0.1
-    end
+    @sessions[session_id]
   end
 end

--- a/lib/puppeteer/connection.rb
+++ b/lib/puppeteer/connection.rb
@@ -45,11 +45,7 @@ class Puppeteer::Connection
     @transport = transport
     @transport.on_message do |data|
       message = JSON.parse(data)
-      if can_handle_async?(message)
-        async_handle_message(message)
-      else
-        handle_message(message)
-      end
+      handle_message(message)
     end
     @transport.on_close do |reason, code|
       handle_close
@@ -62,14 +58,6 @@ class Puppeteer::Connection
   # used only in Browser#connected?
   def closed?
     @closed
-  end
-
-  private def can_handle_async?(message)
-    return true unless message['method']
-
-    # Puppeteer doesn't handle any Network monitoring responses.
-    # So we don't care their handling order.
-    message['method'].start_with?('Network.')
   end
 
   def self.from_session(session)
@@ -231,7 +219,7 @@ class Puppeteer::Connection
         end
       end
     else
-      future { emit_event(message['method'], message['params']) }
+      emit_event(message['method'], message['params'])
     end
   end
 

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -104,7 +104,7 @@ class Puppeteer::Page
     end
     # client.on('Runtime.bindingCalled', event => this._onBindingCalled(event));
     @client.on_event('Page.javascriptDialogOpening') do |event|
-      handle_dialog_opening(event)
+      future { handle_dialog_opening(event) }
     end
     @client.on_event('Runtime.exceptionThrown') do |exception|
       handle_exception(exception['exceptionDetails'])
@@ -117,7 +117,7 @@ class Puppeteer::Page
       handle_log_entry_added(event)
     end
     @client.on_event('Page.fileChooserOpened') do |event|
-      handle_file_chooser(event)
+      future { handle_file_chooser(event) }
     end
     @target.is_closed_promise.then do
       emit_event(PageEmittedEvents::Close)


### PR DESCRIPTION
Asynchronous message handling often brings bug, and ugly workaround logic or sleep is required.
However synchronous message handling is enough in most cases. (It was terribly slow when I developed this Gem, but not so slow now) 