### PR TITLE
Fix full page screenshot

### DIFF
--- a/lib/puppeteer/emulation_manager.rb
+++ b/lib/puppeteer/emulation_manager.rb
@@ -32,7 +32,7 @@ class Puppeteer::EmulationManager
       ),
     )
 
-    reload_needed = @emulating_mobile != mobile || @hasTouch != has_touch
+    reload_needed = @emulating_mobile != mobile || @has_touch != has_touch
     @emulating_mobile = mobile
     @has_touch = has_touch
     reload_needed

--- a/spec/integration/screenshot_spec.rb
+++ b/spec/integration/screenshot_spec.rb
@@ -134,6 +134,34 @@ RSpec.describe 'Screenshots' do
     # });
   end
 
+  # Regression spec for # https://github.com/YusukeIwaki/puppeteer-ruby/issues/96
+  describe 'full_page', sinatra: true do
+    shared_examples 'keep input value' do
+      it {
+        page.goto("#{server_prefix}/input/textarea.html")
+        page.type_text('textarea', 'my value')
+        page.screenshot(full_page: true)
+        expect(page.eval_on_selector('textarea', 'input => input.value')).to eq('my value')
+      }
+    end
+
+    context 'with Mobile viewport' do
+      before {
+        page.viewport = Puppeteer::Devices.iPhone_6.viewport
+      }
+
+      it_behaves_like 'keep input value'
+    end
+
+    context 'with 1200x1200 viewport' do
+      before {
+        page.viewport = Puppeteer::Viewport.new(width: 1200, height: 1200)
+      }
+
+      it_behaves_like 'keep input value'
+    end
+  end
+
   # describe('ElementHandle.screenshot', function () {
   #   it('should work', async () => {
   #     const { page, server } = getTestState();


### PR DESCRIPTION
resolves #96 

current version:

```
Failures:

  1) Screenshots full_page with Mobile viewport behaves like keep input value is expected to eq "my value"
     Failure/Error: expect(page.eval_on_selector('textarea', 'input => input.value')).to eq('my value')
     
       expected: "my value"
            got: ""
     
       (compared using ==)
     Shared Example Group: "keep input value" called from ./spec/integration/screenshot_spec.rb:153
     # ./spec/integration/screenshot_spec.rb:144:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:167:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:92:in `block (3 levels) in <top (required)>'
     # ./lib/puppeteer/puppeteer.rb:71:in `launch'
     # ./lib/puppeteer.rb:79:in `public_send'
     # ./lib/puppeteer.rb:79:in `method_missing'
     # ./spec/spec_helper.rb:90:in `block (2 levels) in <top (required)>'

  2) Screenshots full_page with 1200x1200 viewport behaves like keep input value is expected to eq "my value"
     Failure/Error: expect(page.eval_on_selector('textarea', 'input => input.value')).to eq('my value')
     
       expected: "my value"
            got: ""
     
       (compared using ==)
     Shared Example Group: "keep input value" called from ./spec/integration/screenshot_spec.rb:161
     # ./spec/integration/screenshot_spec.rb:144:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:167:in `block (2 levels) in <top (required)>'
     # ./spec/spec_helper.rb:92:in `block (3 levels) in <top (required)>'
     # ./lib/puppeteer/puppeteer.rb:71:in `launch'
     # ./lib/puppeteer.rb:79:in `public_send'
     # ./lib/puppeteer.rb:79:in `method_missing'
     # ./spec/spec_helper.rb:90:in `block (2 levels) in <top (required)>'

Finished in 6.74 seconds (files took 0.90863 seconds to load)
2 examples, 2 failures
```

after fix:

```
Finished in 5.83 seconds (files took 0.68128 seconds to load)
2 examples, 0 failures
```