### PR TITLE
Reuse browser session among `puppeteer: :page` specs

### DIFF
--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -377,6 +377,10 @@ class Puppeteer::Page
     end
   end
 
+  def clear_cache
+    @client.send_message('Network.clearBrowserCache')
+  end
+
   def clear_cookies
     @client.send_message('Network.clearBrowserCookies')
   end

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -377,6 +377,10 @@ class Puppeteer::Page
     end
   end
 
+  def clear_cookies
+    @client.send_message('Network.clearBrowserCookies')
+  end
+
   # @param url [String?]
   # @param path [String?]
   # @param content [String?]

--- a/spec/integration/cookies_spec.rb
+++ b/spec/integration/cookies_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe 'cookies' do
       ))
     end
 
-    it_fails_firefox 'should set cookies from a frame' do
+    it_fails_firefox 'should set cookies from a frame', disable_web_security: true do
       page.goto("#{server_prefix}/grid.html")
       page.set_cookie(name: 'localhost-cookie', value: 'best')
       js = <<~JAVASCRIPT

--- a/spec/integration/page_spec.rb
+++ b/spec/integration/page_spec.rb
@@ -323,6 +323,7 @@ RSpec.describe Puppeteer::Page do
 
   describe '#offline_mode=' do
     it_fails_firefox 'should work', sinatra: true do
+      page.clear_cache
       page.offline_mode = true
       expect { page.goto(server_empty_page) }.to raise_error(/net::ERR_INTERNET_DISCONNECTED/)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,14 @@ RSpec.configure do |config|
       end
     end
   end
+  config.after(:suite) do
+    if Puppeteer.respond_to?(:cached_browser_ws_endpoint)
+      browser = Puppeteer.connect(
+        browser_ws_endpoint: Puppeteer.cached_browser_ws_endpoint,
+      ) rescue nil
+      browser&.close
+    end
+  end
 
   # Unit test doesn't connect to internet. No need to wait for 30sec. Set it to 7.5sec.
   config.before(:each, type: :puppeteer) do


### PR DESCRIPTION
Launching Firefox spends about 3 seconds. Waiting it for every spec is too slow...
So we reuse the launched browser if possible.

### before

![before](https://user-images.githubusercontent.com/11763113/114728255-e6941480-9d79-11eb-9f7f-c04d3292eb4f.gif)


### after

![after](https://user-images.githubusercontent.com/11763113/114728009-aaf94a80-9d79-11eb-8bed-0b6bf12137bc.gif)
