### PR TITLE
raise LaunchError when Chrome crashed on launch.

### DIFF
--- a/lib/puppeteer/browser_runner.rb
+++ b/lib/puppeteer/browser_runner.rb
@@ -161,14 +161,18 @@ class Puppeteer::BrowserRunner
   end
 
   private def wait_for_ws_endpoint(browser_process, timeout, preferred_revision)
+    lines = []
     Timeout.timeout(timeout / 1000.0) do
       loop do
         line = browser_process.stderr.readline
         /^DevTools listening on (ws:\/\/.*)$/.match(line) do |m|
           return m[1]
         end
+        lines << line
       end
     end
+  rescue EOFError
+    raise LaunchError.new("\n#{lines.join("\n")}\nTROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md")
   rescue Timeout::Error
     raise Puppeteer::TimeoutError.new("Timed out after #{timeout} ms while trying to connect to the browser! Only Chrome at revision r#{preferred_revision} is guaranteed to work.")
   end


### PR DESCRIPTION
Another implementation for #105 

### before

```
    EOFError:
       end of file reached
```

### after

```
     Puppeteer::BrowserRunner::LaunchError:
       Failed to launch browser! 
       [19476:19476:0518/105840.008914:ERROR:browser_main_loop.cc(1473)] Unable to open X display.
     
       [0518/105840.067136:ERROR:nacl_helper_linux.cc(308)] NaCl helper process running without a sandbox!
     
       Most likely you need to configure your SUID sandbox correctly
     
       TROUBLESHOOTING: https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md
```