### PR TITLE
Specify required Ruby version

### DIFF
--- a/puppeteer-ruby.gemspec
+++ b/puppeteer-ruby.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.6'
   spec.add_dependency 'concurrent-ruby', '~> 1.1.0'
   spec.add_dependency 'websocket-driver', '>= 0.6.0'
   spec.add_dependency 'mime-types', '>= 3.0'


### PR DESCRIPTION
refs #118 

This gem is not tested on Ruby 2.3, 2.4, 2.5, and actually not working on them. https://github.com/YusukeIwaki/puppeteer-ruby/pull/120
We should specify required Ruby version.