### PR TITLE
Fix calculation logic for PDF options

### DIFF
--- a/lib/puppeteer/page/pdf_options.rb
+++ b/lib/puppeteer/page/pdf_options.rb
@@ -78,15 +78,15 @@ class Puppeteer::Page
 
       pixels =
         if parameter.is_a?(Numeric)
-          parameter.to_i
+          parameter
         elsif parameter.is_a?(String)
           unit = parameter[-2..-1].downcase
           value =
             if UNIT_TO_PIXELS.has_key?(unit)
-              parameter[0...-2].to_i
+              parameter[0...-2].to_f
             else
               unit = 'px'
-              parameter.to_i
+              parameter.to_f
             end
 
           value * UNIT_TO_PIXELS[unit]
@@ -94,7 +94,7 @@ class Puppeteer::Page
           raise ArgumentError.new("page.pdf() Cannot handle parameter type: #{parameter.class}")
         end
 
-      pixels / 96
+      pixels / 96.0
     end
 
     private def paper_size

--- a/spec/puppeteer/page/pdf_options_spec.rb
+++ b/spec/puppeteer/page/pdf_options_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe Puppeteer::Page::PDFOptions do
+  describe 'convert_print_parameter_to_inches' do
+    let(:instance) { Puppeteer::Page::PDFOptions.new(options) }
+    let(:options) { { path: 'x.pdf' } }
+    subject { instance.send(:convert_print_parameter_to_inches, value) }
+
+    context 'value is nil' do
+      let(:value) { nil }
+      it { is_expected.to be_nil }
+    end
+
+    context 'value is number' do
+      let(:value) { 10 }
+      it { is_expected.to eq(10 / 96.0) }
+    end
+
+    context 'value is decimal' do
+      let(:value) { 10.5 }
+      it { is_expected.to eq(10.5 / 96.0) }
+    end
+
+    context 'value is number without unit' do
+      let(:value) { "10" }
+      it { is_expected.to eq(10 / 96.0) }
+    end
+
+    context 'value is number with unit' do
+      let(:value) { "10cm" }
+      it { is_expected.to eq(10 * 37.8 / 96.0) }
+    end
+
+    context 'value is decimal with unit' do
+      let(:value) { "10.5cm" }
+      it { is_expected.to eq(10.5 * 37.8 / 96.0) }
+    end
+  end
+end


### PR DESCRIPTION
fixes #119 

spec failed before fix:

```
Failures:

  1) Puppeteer::Page::PDFOptions convert_print_parameter_to_inches value is number is expected to eq 0.10416666666666667
     Failure/Error: it { is_expected.to eq(10 / 96.0) }
     
       expected: 0.10416666666666667
            got: 0
     
       (compared using ==)
     # ./spec/puppeteer/page/pdf_options_spec.rb:16:in `block (4 levels) in <top (required)>'

  2) Puppeteer::Page::PDFOptions convert_print_parameter_to_inches value is decimal is expected to eq 0.109375
     Failure/Error: it { is_expected.to eq(10.5 / 96.0) }
     
       expected: 0.109375
            got: 0
     
       (compared using ==)
     # ./spec/puppeteer/page/pdf_options_spec.rb:21:in `block (4 levels) in <top (required)>'

  3) Puppeteer::Page::PDFOptions convert_print_parameter_to_inches value is number without unit is expected to eq 0.10416666666666667
     Failure/Error: it { is_expected.to eq(10 / 96.0) }
     
       expected: 0.10416666666666667
            got: 0
     
       (compared using ==)
     # ./spec/puppeteer/page/pdf_options_spec.rb:26:in `block (4 levels) in <top (required)>'

  4) Puppeteer::Page::PDFOptions convert_print_parameter_to_inches value is decimal with unit is expected to eq 4.1343749999999995
     Failure/Error: it { is_expected.to eq(10.5 * 37.8 / 96.0) }
     
       expected: 4.1343749999999995
            got: 3.9375
     
       (compared using ==)
     # ./spec/puppeteer/page/pdf_options_spec.rb:36:in `block (4 levels) in <top (required)>'

Finished in 0.0335 seconds (files took 0.75016 seconds to load)
6 examples, 4 failures
```