### PR TITLE
Define sync API with block

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,13 @@ Puppeteer.launch(headless: false, slow_mo: 50, args: ['--guest', '--window-size=
   page.goto("https://github.com/", wait_until: 'domcontentloaded')
 
   form = page.query_selector("form.js-site-search-form")
-  searchInput = form.query_selector("input.header-search-input")
-  searchInput.type_text("puppeteer")
-  await_all(
-    page.async_wait_for_navigation,
-    searchInput.async_press("Enter"),
-  )
+  search_input = form.query_selector("input.header-search-input")
+  search_input.click
+  page.keyboard.type_text("puppeteer")
+
+  page.wait_for_navigation do
+    search_input.press('Enter')
+  end
 
   list = page.query_selector("ul.repo-list")
   items = list.query_selector_all("div.f4")
@@ -136,10 +137,9 @@ RSpec.describe 'hotel.testplanisphere.dev', type: :feature do
 
     reservation_link = puppeteer_page.query_selector_all('li.nav-item')[1]
 
-    await_all(
-      puppeteer_page.async_wait_for_navigation,
-      reservation_link.async_click,
-    )
+    puppeteer_page.wait_for_navigation do
+      reservation_link.click
+    end
 
     # expectation with Capybara DSL
     expect(page).to have_text('宿泊プラン一覧')

--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -131,9 +131,9 @@
 * ~~waitFor~~
 * waitForFileChooser => `#wait_for_file_chooser`
 * waitForFunction => `#wait_for_function`
-* waitForNavigation => `#async_wait_for_navigation`
-* waitForRequest => `#async_wait_for_request`
-* waitForResponse => `#async_wait_for_response`
+* waitForNavigation => `#wait_for_navigation`
+* waitForRequest => `#wait_for_request`
+* waitForResponse => `#wait_for_response`
 * waitForSelector => `#wait_for_selector`
 * waitForTimeout => `#wait_for_timeout`
 * waitForXPath => `#wait_for_xpath`
@@ -226,7 +226,7 @@
 * url
 * ~~waitFor~~
 * waitForFunction => `#wait_for_function`
-* waitForNavigation => `#async_wait_for_navigation`
+* waitForNavigation => `#wait_for_navigation`
 * waitForSelector => `#wait_for_selector`
 * waitForTimeout => `#wait_for_timeout`
 * waitForXPath => `#wait_for_xpath`

--- a/lib/puppeteer/define_async_method.rb
+++ b/lib/puppeteer/define_async_method.rb
@@ -9,22 +9,73 @@ module Puppeteer::DefineAsyncMethod
         raise ArgumentError.new("#{async_method_name} is already defined")
       end
 
-      original_method = instance_method(async_method_name[6..-1])
+      original_method_name = async_method_name[6..-1]
+      original_method = instance_method(original_method_name)
+
+      # - Modify only wait_for_xxx
+      # - Do not modify private methods.
+      if method_defined?(original_method_name) && original_method_name.start_with?('wait_for_')
+        # def wait_for_xxx(xx, yy, &block)
+        #
+        # -> await_all(
+        #      async_wait_for_xxx(xx, yy),
+        #      future { block.call },
+        #    ).first
+        define_method(original_method_name) do |*args, **kwargs, &block|
+          if block
+            async_method_call =
+              if kwargs.empty? # for Ruby 2.6
+                Concurrent::Promises.future do
+                  original_method.bind(self).call(*args)
+                rescue => err
+                  Logger.new($stderr).warn(err)
+                  raise err
+                end
+              else
+                Concurrent::Promises.future do
+                  original_method.bind(self).call(*args, **kwargs)
+                rescue => err
+                  Logger.new($stderr).warn(err)
+                  raise err
+                end
+              end
+
+            async_block_call = Concurrent::Promises.future do
+              block.call
+            rescue => err
+              Logger.new($stderr).warn(err)
+              raise err
+            end
+
+            Concurrent::Promises.zip(
+              async_method_call,
+              async_block_call,
+            ).value!.first
+          else
+            if kwargs.empty? # for Ruby 2.6
+              original_method.bind(self).call(*args)
+            else
+              original_method.bind(self).call(*args, **kwargs)
+            end
+          end
+        end
+      end
+
       define_method(async_method_name) do |*args, **kwargs|
-        if kwargs.empty? # for Ruby < 2.7
+        if kwargs.empty? # for Ruby 2.6
           Concurrent::Promises.future do
             original_method.bind(self).call(*args)
           rescue => err
             Logger.new($stderr).warn(err)
             raise err
-          end
+          end.extend(Puppeteer::ConcurrentRubyUtils::ConcurrentPromisesFutureExtension)
         else
           Concurrent::Promises.future do
             original_method.bind(self).call(*args, **kwargs)
           rescue => err
             Logger.new($stderr).warn(err)
             raise err
-          end
+          end.extend(Puppeteer::ConcurrentRubyUtils::ConcurrentPromisesFutureExtension)
         end
       end
     end

--- a/lib/puppeteer/frame.rb
+++ b/lib/puppeteer/frame.rb
@@ -35,7 +35,7 @@ class Puppeteer::Frame
 
   # @param timeout [number|nil]
   # @param wait_until [string|nil] 'load' | 'domcontentloaded' | 'networkidle0' | 'networkidle2'
-  private def wait_for_navigation(timeout: nil, wait_until: nil)
+  def wait_for_navigation(timeout: nil, wait_until: nil)
     @frame_manager.wait_for_frame_navigation(self, timeout: timeout, wait_until: wait_until)
   end
 

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -637,7 +637,7 @@ class Puppeteer::Page
     ).first
   end
 
-  private def wait_for_navigation(timeout: nil, wait_until: nil)
+  def wait_for_navigation(timeout: nil, wait_until: nil)
     main_frame.send(:wait_for_navigation, timeout: timeout, wait_until: wait_until)
   end
 
@@ -683,7 +683,7 @@ class Puppeteer::Page
     end
   end
 
-  private def wait_for_request(url: nil, predicate: nil, timeout: nil)
+  def wait_for_request(url: nil, predicate: nil, timeout: nil)
     if !url && !predicate
       raise ArgumentError.new('url or predicate must be specified')
     end
@@ -717,7 +717,7 @@ class Puppeteer::Page
   # @param predicate [Proc(Puppeteer::Request -> Boolean)]
   define_async_method :async_wait_for_request
 
-  private def wait_for_response(url: nil, predicate: nil, timeout: nil)
+  def wait_for_response(url: nil, predicate: nil, timeout: nil)
     if !url && !predicate
       raise ArgumentError.new('url or predicate must be specified')
     end

--- a/spec/integration/browser_context_spec.rb
+++ b/spec/integration/browser_context_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Puppeteer::BrowserContext, puppeteer: :browser do
       page = context.new_page
       page.goto('about:blank')
 
-      popup_target = await_all(
-        resolvable_future { |f| browser.once('targetcreated') { |target| f.fulfill(target) } },
-        page.async_evaluate('url => { window.open(url); return null }', 'about:blank'),
-      ).first
+      target_promise = resolvable_future { |f| browser.once('targetcreated') { |target| f.fulfill(target) } }
+      popup_target = target_promise.with_waiting_for_complete do
+        page.evaluate('url => { window.open(url); return null }', 'about:blank')
+      end
       expect(popup_target.browser_context).to eq(context)
       context.close
     end

--- a/spec/integration/click_spec.rb
+++ b/spec/integration/click_spec.rb
@@ -65,10 +65,9 @@ RSpec.describe Puppeteer::Page do
     page.javascript_enabled = false
     page.goto("#{server_prefix}/wrappedlink.html")
 
-    await_all(
-      page.async_wait_for_navigation,
-      page.async_click('a'),
-    )
+    page.wait_for_navigation do
+      page.click('a')
+    end
     expect(page.url).to eq("#{server_prefix}/wrappedlink.html#clicked")
   end
 

--- a/spec/integration/example_spec.rb
+++ b/spec/integration/example_spec.rb
@@ -57,12 +57,11 @@ RSpec.describe 'example' do
     form = page.query_selector("form.js-site-search-form")
     search_input = form.query_selector("input.header-search-input")
     search_input.click
-
     page.keyboard.type_text("puppeteer")
-    await_all(
-      page.async_wait_for_navigation,
-      search_input.async_press("Enter"),
-    )
+
+    page.wait_for_navigation do
+      search_input.press("Enter")
+    end
 
     list = page.query_selector("ul.repo-list")
     items = list.query_selector_all("div.f4")

--- a/spec/integration/input_spec.rb
+++ b/spec/integration/input_spec.rb
@@ -37,10 +37,9 @@ RSpec.describe 'input tests' do
   describe 'Page#wait_for_file_chooser' do
     it_fails_firefox 'should work when file input is attached to DOM' do
       page.content = '<input type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_click('input'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
       expect(chooser).to be_a(Puppeteer::FileChooser)
     end
     it_fails_firefox 'should work when file input is not attached to DOM' do
@@ -52,10 +51,9 @@ RSpec.describe 'input tests' do
       }
       JAVASCRIPT
 
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_evaluate(js),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.evaluate(js)
+      end
       expect(chooser).to be_a(Puppeteer::FileChooser)
     end
     it 'should respect timeout' do
@@ -80,10 +78,9 @@ RSpec.describe 'input tests' do
       }
       JAVASCRIPT
 
-      chooser = await_all(
-        page.async_wait_for_file_chooser(timeout: 0),
-        page.async_evaluate(js),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.evaluate(js)
+      end
       expect(chooser).to be_a(Puppeteer::FileChooser)
     end
     it_fails_firefox 'should return the same file chooser when there are many watchdogs simultaneously' do
@@ -102,10 +99,9 @@ RSpec.describe 'input tests' do
 
     it_fails_firefox 'should accept single file' do
       page.content = "<input type=file oninput='javascript:console.timeStamp()'>"
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_click('input'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
       chooser.accept(filepath)
       expect(page.eval_on_selector('input', "(input) => input.files.length")).to eq(1)
       expect(page.eval_on_selector('input', "(input) => input.files[0].name")).to eq("file-to-upload.txt")
@@ -159,27 +155,24 @@ RSpec.describe 'input tests' do
     end
     it_fails_firefox 'should not accept multiple files for single-file input' do
       page.content = '<input type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_click('input'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
       pprt_png = File.join('spec', 'assets', 'pptr.png')
       expect { chooser.accept([filepath, pprt_png]) }.to raise_error(/Multiple file uploads only work with <input type=file multiple>/)
     end
     it_fails_firefox 'should fail for non-existent files' do
       page.content = '<input type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_click('input'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
       expect { chooser.accept(['file-does-not-exist.txt']) }.to raise_error(/file-does-not-exist.txt does not exist or is not readable/)
     end
     it_fails_firefox 'should fail when accepting file chooser twice' do
       page.content = '<input type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_eval_on_selector('input', '(input) => input.click()'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.eval_on_selector('input', '(input) => input.click()')
+      end
       chooser.accept([])
       expect { chooser.accept([]) }.to raise_error(/Cannot accept FileChooser which is already handled!/)
     end
@@ -192,27 +185,24 @@ RSpec.describe 'input tests' do
       # canceled.
 
       page.content = '<input type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_eval_on_selector('input', '(input) => input.click()'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.eval_on_selector('input', '(input) => input.click()')
+      end
       chooser.cancel
 
       # If this resolves, than we successfully canceled file chooser.
       Timeout.timeout(2) do
-        await_all(
-          page.async_wait_for_file_chooser,
-          page.async_eval_on_selector('input', '(input) => input.click()'),
-        )
+        chooser = page.wait_for_file_chooser do
+          page.eval_on_selector('input', '(input) => input.click()')
+        end
       end
     end
 
     it_fails_firefox 'should fail when canceling file chooser twice' do
       page.content = '<input type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_eval_on_selector('input', '(input) => input.click()'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.eval_on_selector('input', '(input) => input.click()')
+      end
       chooser.cancel
       expect { chooser.cancel }.to raise_error(/Cannot cancel FileChooser which is already handled!/)
     end
@@ -221,26 +211,23 @@ RSpec.describe 'input tests' do
   describe 'FileChooser#multiple?' do
     it_fails_firefox 'should work for single file pick' do
       page.content = '<input type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_click('input'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
       expect(chooser).not_to be_multiple
     end
     it_fails_firefox 'should work for "multiple"' do
       page.content = '<input multiple type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_click('input'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
       expect(chooser).to be_multiple
     end
     it_fails_firefox 'should work for "webkitdirectory"' do
       page.content = '<input multiple webkitdirectory type=file>'
-      chooser = await_all(
-        page.async_wait_for_file_chooser,
-        page.async_click('input'),
-      ).first
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
       expect(chooser).to be_multiple
     end
   end

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -374,10 +374,10 @@ RSpec.describe Puppeteer::Launcher do
       remote_browser = Puppeteer.connect(browser_ws_endpoint: browser.ws_endpoint)
 
       Timeout.timeout(3) do
-        await_all(
-          resolvable_future { |f| browser.once('disconnected') { f.fulfill(nil) } },
-          future { remote_browser.close },
-        )
+        disconnected_promise = resolvable_future { |f| browser.once('disconnected') { f.fulfill(nil) } }
+        disconnected_promise.with_waiting_for_complete do
+          remote_browser.close
+        end
       end
     end
 
@@ -504,10 +504,10 @@ RSpec.describe Puppeteer::Launcher do
       remote_browser1.on('disconnected') { disconnected_remote1 += 1 }
       remote_browser2.on('disconnected') { disconnected_remote2 += 1 }
 
-      await_all(
-        resolvable_future { |f| remote_browser2.once('disconnected') { |frame| f.fulfill(frame) } },
-        future { remote_browser2.disconnect },
-      )
+      disconnected_promise = resolvable_future { |f| remote_browser2.once('disconnected') { |frame| f.fulfill(frame) } }
+      disconnected_promise.with_waiting_for_complete do
+        remote_browser2.disconnect
+      end
 
       expect(disconnected_original).to eq(0)
       expect(disconnected_remote1).to eq(0)

--- a/spec/integration/page_spec.rb
+++ b/spec/integration/page_spec.rb
@@ -100,10 +100,10 @@ RSpec.describe Puppeteer::Page do
   describe 'Page.Events.Load' do
     it 'should fire when expected' do
       Timeout.timeout(5) do
-        await_all(
-          future { page.goto("about:blank") },
-          resolvable_future { |f| page.once('load') { f.fulfill(nil) } },
-        )
+        load_promise = resolvable_future { |f| page.once('load') { f.fulfill(nil) } }
+        load_promise.with_waiting_for_complete do
+          page.goto("about:blank")
+        end
       end
     end
   end

--- a/spec/integration/wait_task_spec.rb
+++ b/spec/integration/wait_task_spec.rb
@@ -44,10 +44,9 @@ RSpec.describe Puppeteer::WaitTask do
 
     it 'should wait for predicate' do
       Timeout.timeout(1) do # assert not timeout.
-        await_all(
-          page.async_wait_for_function('() => window.innerWidth < 100'),
-          future { page.viewport = Puppeteer::Viewport.new(width: 10, height: 10) },
-        )
+        page.wait_for_function('() => window.innerWidth < 100') do
+          page.viewport = Puppeteer::Viewport.new(width: 10, height: 10)
+        end
       end
     end
 
@@ -75,10 +74,11 @@ RSpec.describe Puppeteer::WaitTask do
     it_fails_firefox 'should work with removed MutationObserver' do
       page.evaluate("() => delete window.MutationObserver")
 
-      handle = await_all(
-        page.async_wait_for_selector('.zombo'),
-        future { sleep 0.1; page.content = "<div class='zombo'>anything</div>" },
-      ).first
+
+      handle = page.wait_for_selector('.zombo') do
+        sleep 0.1
+        page.content = "<div class='zombo'>anything</div>"
+      end
       expect(page.evaluate("(x) => x.textContent", handle)).to eq('anything')
     end
 

--- a/spec/puppeteer/concurrent_ruby_utils_spec.rb
+++ b/spec/puppeteer/concurrent_ruby_utils_spec.rb
@@ -47,6 +47,26 @@ RSpec.describe Puppeteer::ConcurrentRubyUtils do
     end
   end
 
+  describe 'with_waiting_for_complete' do
+    it 'wait for complete' do
+      start = Time.now
+      result = future { sleep 0.5 ; 3 }.with_waiting_for_complete do
+        sleep 0.3
+      end
+      expect(Time.now - start).to be >= 0.5
+      expect(result).to eq(3)
+    end
+
+    it 'wait for block call' do
+      start = Time.now
+      result = future { sleep 0.3 ; 3 }.with_waiting_for_complete do
+        sleep 0.5
+      end
+      expect(Time.now - start).to be >= 0.5
+      expect(result).to eq(3)
+    end
+  end
+
   describe 'await_any' do
     it 'wait first future' do
       start = Time.now


### PR DESCRIPTION
resolves #123 

Async API:

```ruby
await_all(
  page.async_wait_for_navigation,
  page.async_click('#submit'),
)
```

Sync API with block:

```ruby
page.wait_for_navigation do
  page.click('#submit')
end
```

Async API is familiar to JavaScript users, however Ruby users would like to use Sync API.