### PR TITLE
Improve define_async_method.

### DIFF
--- a/lib/puppeteer/concurrent_ruby_utils.rb
+++ b/lib/puppeteer/concurrent_ruby_utils.rb
@@ -3,11 +3,11 @@ module Puppeteer::ConcurrentRubyUtils
   module ConcurrentPromisesFutureExtension
     # Extension for describing 2 concurrent tasks smartly.
     #
-    # page.async_for_navigation.with_waiting_for_complete do
+    # page.async_wait_for_navigation.with_waiting_for_complete do
     #   page.click('#submit')
     # end
     def with_waiting_for_complete(&block)
-      async_block_call = Concurrent::Promises.future do
+      async_block_call = Concurrent::Promises.delay do
         block.call
       rescue => err
         Logger.new($stderr).warn(err)

--- a/lib/puppeteer/define_async_method.rb
+++ b/lib/puppeteer/define_async_method.rb
@@ -40,7 +40,7 @@ module Puppeteer::DefineAsyncMethod
                 end
               end
 
-            async_block_call = Concurrent::Promises.future do
+            async_block_call = Concurrent::Promises.delay do
               block.call
             rescue => err
               Logger.new($stderr).warn(err)

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -133,7 +133,7 @@ RSpec.describe Puppeteer::Launcher do
       end
     end
 
-    it_fails_firefox 'user_data_dir option should restore cookies', sinatra: true do
+    it 'user_data_dir option should restore cookies', sinatra: true do
       Dir.mktmpdir do |user_data_dir|
         options = default_launch_options.merge(
           user_data_dir: user_data_dir,


### PR DESCRIPTION
The block call of wait_for_xxx should be evaluated after wait_for_xxx. However Concurrent::Promises.zip(promises) don't ensure the order of evaluation of promises.

```ruby
      js = <<~JAVASCRIPT
      () => {
        const el = document.createElement('input');
        el.type = 'file';
        el.click();
      }
      JAVASCRIPT

      chooser = page.wait_for_file_chooser do
        page.evaluate(js)
      end
```

This spec often failed:

```
D, [2021-08-14T12:54:05.059535 #1144] DEBUG -- : SEND >> {"sessionId":"F60931875D40811439D39D5418D08D05","method":"Runtime.callFunctionOn","params":{"functionDeclaration":"() => {\n  const el = document.createElement('input');\n  el.type = 'file';\n  el.click();\n}\n\n//# sourceURL=__puppeteer_evaluation_script__\n","executionContextId":1,"arguments":[],"returnByValue":true,"awaitPromise":true,"userGesture":true},"id":16}
D, [2021-08-14T12:54:05.059574 #1144] DEBUG -- : SEND >> {"sessionId":"F60931875D40811439D39D5418D08D05","method":"Page.setInterceptFileChooserDialog","params":{"enabled":true},"id":17}
D, [2021-08-14T12:54:05.065036 #1144] DEBUG -- : RECV << {"id"=>16, "result"=>{"result"=>{"type"=>"undefined"}}, "sessionId"=>"F60931875D40811439D39D5418D08D05"}
D, [2021-08-14T12:54:05.069328 #1144] DEBUG -- : RECV << {"id"=>17, "result"=>{}, "sessionId"=>"F60931875D40811439D39D5418D08D05"}
..W, [2021-08-14T12:54:12.569836 #1144]  WARN -- : waiting for filechooser failed: timeout 7500ms exceeded (Puppeteer::Page::FileChooserTimeoutError)
/home/circleci/project/lib/puppeteer/page.rb:191:in `rescue in wait_for_file_chooser'
/home/circleci/project/lib/puppeteer/page.rb:190:in `wait_for_file_chooser'
/home/circleci/project/lib/puppeteer/define_async_method.rb:29:in `call'
/home/circleci/project/lib/puppeteer/define_async_method.rb:29:in `block (2 levels) in define_async_method'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:1582:in `evaluate_to'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:1765:in `block in on_resolvable'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:363:in `run_task'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:352:in `block (3 levels) in create_worker'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `loop'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:335:in `block (2 levels) in create_worker'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `catch'
/home/circleci/.rubygems/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/executor/ruby_thread_pool_executor.rb:334:in `block in create_worker'
    should work when file input is not attached to DOM (FAILED - 1)
```

The main cause is invalid order of `wait_for_file_chooser` and `page.evaluate`

For evaluating `page.evaluate` later, let's use `Concurrent::Promises.delay` instead of `Concurrent::Promises.future`

```ruby
async_xxxx = Concurrent::Promises.future { ... } # start evaluating here.
async_calling_block = Concurrent::Promises.delay { ... } # not evaluated here.

Concurrent::Promises.zip(
  async_xxx, # already started to be evaluated
  axync_calling_block, # not evaluated yet
).value! # async_calling_block starts to be evaluated here.
```