### PR TITLE
Fix bug where signal handlers can not be configured to be disabled (e.g. configured with false value)

### DIFF
--- a/lib/puppeteer/launcher/launch_options.rb
+++ b/lib/puppeteer/launcher/launch_options.rb
@@ -35,9 +35,9 @@ module Puppeteer::Launcher
       @channel = options[:channel]
       @executable_path = options[:executable_path]
       @ignore_default_args = options[:ignore_default_args] || false
-      @handle_SIGINT = options[:handle_SIGINT] || true
-      @handle_SIGTERM = options[:handle_SIGTERM] || true
-      @handle_SIGHUP = options[:handle_SIGHUP] || true
+      @handle_SIGINT = options.fetch(:handle_SIGINT, true)
+      @handle_SIGTERM = options.fetch(:handle_SIGTERM, true)
+      @handle_SIGHUP = options.fetch(:handle_SIGHUP, true)
       @timeout = options[:timeout] || 30000
       @dumpio = options[:dumpio] || false
       @env = options[:env] || ENV

--- a/spec/puppeteer/launcher/launch_options_spec.rb
+++ b/spec/puppeteer/launcher/launch_options_spec.rb
@@ -44,4 +44,21 @@ RSpec.describe Puppeteer::Launcher::LaunchOptions do
       expect(subject.pipe?).to eq(false)
     end
   end
+
+  describe "disabled signal handlers" do
+    it 'handle_SIGINT can be disabled' do
+      opts = Puppeteer::Launcher::LaunchOptions.new({handle_SIGINT: false})
+      expect(opts.handle_SIGINT?).to eq(false)
+    end
+
+    it 'handle_SIGTERM can be disabled' do
+      opts = Puppeteer::Launcher::LaunchOptions.new({handle_SIGTERM: false})
+      expect(opts.handle_SIGTERM?).to eq(false)
+    end
+
+    it 'handle_SIGHUP can be disabled' do
+      opts = Puppeteer::Launcher::LaunchOptions.new({handle_SIGHUP: false})
+      expect(opts.handle_SIGHUP?).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
- Add tests for launch options default values
- Fix support for disabling signal handlers
