### PR TITLE
Better interact with other systems by using at_exit instead of trap(:EXIT)

### DIFF
--- a/lib/puppeteer/browser_runner.rb
+++ b/lib/puppeteer/browser_runner.rb
@@ -94,7 +94,7 @@ class Puppeteer::BrowserRunner
         FileUtils.rm_rf(@temp_directory)
       end
     }
-    trap(:EXIT) do
+    at_exit do
       kill
     end
 


### PR DESCRIPTION
Ruby allows for multiple `at_exit`-callbacks but only runs the last registered `trap(:EXIT)` handler.

This change should make sure the signal handler is not stolen by another component (or even another instance of puppeteer).

Neither `trap(:EXIT)` nor `at_exit` will run when ruby is terminated by a call to exit! or by uncaught SIGKILL.
See examples below:

```
$ ruby <<EOF
    trap(:EXIT) { puts "trap exit 1" }
    trap(:EXIT) { puts "trap exit 2" }
    at_exit { puts "at_exit 1"}
    at_exit { puts "at_exit 2"}
    exit
EOF
> trap exit 2
> at_exit 2
> at_exit 1

$ ruby <<EOF
    pid = fork do 
        trap(:EXIT) { puts "trap exit 1" }
        trap(:EXIT) { puts "trap exit 2" }
        at_exit { puts "at_exit 1"}
        at_exit { puts "at_exit 2"}
        sleep(10000)
    end
    Process.kill("TERM", pid)
EOF
> trap exit 2
> at_exit 2
> at_exit 1

$ ruby <<EOF
    trap(:EXIT) { puts "trap exit 1" }
    trap(:EXIT) { puts "trap exit 2" }
    at_exit { puts "at_exit 1"}
    at_exit { puts "at_exit 2"}
    exit!
EOF
> (no output)

$ ruby <<EOF
    pid = fork do 
        trap(:EXIT) { puts "trap exit 1" }
        trap(:EXIT) { puts "trap exit 2" }
        at_exit { puts "at_exit 1"}
        at_exit { puts "at_exit 2"}
        sleep(10000)
    end
    Process.kill("KILL", pid)
EOF
> (no output)
```
