### PR TITLE
Fix rspec_alpine CI

### DIFF
--- a/.github/workflows/rspec_alpine.yml
+++ b/.github/workflows/rspec_alpine.yml
@@ -4,9 +4,13 @@ on: [pull_request]
 
 jobs:
   integration_test_with_alpine:
-    name: (Ruby2.7-alpine) Integration Test
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby_version: ['2.7', '3.0']
+    name: (Ruby${{ matrix.ruby_version }}-alpine) Integration Test
     runs-on: ubuntu-latest
-    container: ruby:2.7-alpine
+    container: ruby:${{ matrix.ruby_version }}-alpine
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,6 +51,12 @@ RSpec.configure do |config|
     launch_options[:args] = args
   end
 
+  # Every browser automation test case should spend less than 15sec.
+  if Puppeteer.env.ci?
+    config.around(:each, type: :puppeteer) do |example|
+      Timeout.timeout(15) { example.run }
+    end
+  end
 
   config.around(:each, type: :puppeteer) do |example|
     if ENV['PENDING_CHECK'] && !example.metadata[:pending]
@@ -114,13 +120,6 @@ RSpec.configure do |config|
   # Unit test doesn't connect to internet. No need to wait for 30sec. Set it to 7.5sec.
   config.before(:each, type: :puppeteer) do
     stub_const("Puppeteer::TimeoutSettings::DEFAULT_TIMEOUT", 7500)
-  end
-
-  # Every browser automation test case should spend less than 15sec.
-  if Puppeteer.env.ci?
-    config.around(:each, type: :puppeteer) do |example|
-      Timeout.timeout(15) { example.run }
-    end
   end
 
   config.define_derived_metadata(file_path: %r(/spec/integration/)) do |metadata|


### PR DESCRIPTION
set `Timeout.timeout { ... }` outside Puppeteer.launch.

Puppeteer.launch sometimes hang on Alpine Linux.