### PR TITLE
Fix: spelling of forget_request_paused method

### DIFF
--- a/lib/puppeteer/network_event_manager.rb
+++ b/lib/puppeteer/network_event_manager.rb
@@ -96,7 +96,7 @@ class Puppeteer::NetworkEventManager
     @request_paused_map[network_request_id]
   end
 
-  def fotget_request_paused(network_request_id)
+  def forget_request_paused(network_request_id)
     @request_paused_map.delete(network_request_id)
   end
 


### PR DESCRIPTION
This previously caused a crash when applying a response listener.