### PR TITLE
Prevent SIGINT to be passed into Chrome

### DIFF
--- a/lib/puppeteer/browser_runner.rb
+++ b/lib/puppeteer/browser_runner.rb
@@ -31,7 +31,9 @@ class Puppeteer::BrowserRunner
           [executable_path]
         end
 
-      stdin, @stdout, @stderr, @thread = Open3.popen3(env, executable_path, *args)
+      popen3_args = args || []
+      popen3_args << { pgroup: true } unless Puppeteer.env.windows?
+      stdin, @stdout, @stderr, @thread = Open3.popen3(env, executable_path, *popen3_args)
       stdin.close
       @pid = @thread.pid
     rescue Errno::ENOENT => err


### PR DESCRIPTION
resolves #194 

### before

```
From: /Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/bin/console:14 :

     9: # (If you use this, don't forget to add pry to your Gemfile!)
    10: require 'pry'
    11: Puppeteer.launch(channel: 'chrome', handle_SIGINT: false) do |browser|
    12:   page = browser.new_page
    13:   binding.pry
 => 14: end

[1] pry(main)> 
[1] pry(main)> page.goto('https://github.com/YusukeIwaki')
W, [2022-02-01T23:27:51.584141 #61772]  WARN -- : Protocol error (Page.navigate): Session closed. Most likely the page has been closed. (Puppeteer::CDPSession::Error)
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/cdp_session.rb:37:in `async_send_message'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/cdp_session.rb:29:in `send_message'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/frame_manager.rb:119:in `block in navigate_frame'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/lib/puppeteer/concurrent_ruby_utils.rb:62:in `block in future'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/3.0.0/gems/concurrent-ruby-1.1.9/lib/concurrent-ruby/concurrent/promises.rb:1582:in `evaluate_to'
/Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/vendor/bundle/ruby/3.0.0/gems/concurrent-ruby-1.1.9/lib/co
```

### after

```
From: /Users/yusuke-iwaki/src/github.com/YusukeIwaki/puppeteer-ruby/bin/console:14 :

     9: # (If you use this, don't forget to add pry to your Gemfile!)
    10: require 'pry'
    11: Puppeteer.launch(channel: 'chrome', handle_SIGINT: false) do |browser|
    12:   page = browser.new_page
    13:   binding.pry
 => 14: end

[1] pry(main)> 
[1] pry(main)> page.goto('https://github.com/YusukeIwaki')
=> #<Puppeteer::HTTPRequest @remote_address=#<Puppeteer::HTTPResponse::RemoteAddress:0x00007fe6a52956d8> @url=https://github.com/YusukeIwaki @status=200 @status_text= @headers={"server"=>"GitHub.com", "date"=>"Tue, 01 Feb 2022 14:27:29 GMT", "content-type"=>"text/html; charset=utf-8", "vary"=>"X-Requested-With, X-PJAX-Container, Accept-Encoding, Accept, X-Requested-With", "permissions-policy"=>"interest-cohort=()", "etag"=>"W/\"7eca8805e4a78f7e678ae6dd21222d51\"", "cache-control"=>"max-age=0, private, must-revalidate", "strict-transport-security"=>"max-age=31536000; includeSubdomains; preload", "x-frame-options"=>"deny", "x-content-type-options"=>"nosniff", "x-xss-protection"=>"0", "referrer-policy"=>"origin-when-cross-origin, strict-origin-when-cross-origin", "expect-ct"=>"max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"", "content-security-policy"=>"default-src 'none'; base-uri 'self'; block-all-mixed-content; child-src github.com/assets-cdn/worker/ gist.github.com/assets-cdn/worker/; connect-src 'self' uploads.github.com objects-origin.githubusercontent.com www.githubstatus.com collector.githubapp.com collector.github.com api.github.com github-cloud.s3.amazonaws.com github-production-repository-file-5c1aeb.s3.amazonaws.com github-production-upload-manifest-file-7fdce7.s3.amazonaws.com github-production-user-asset-6210df.s3.amazonaws.com cdn.optimizely.com logx.optimizely.com/v1/events
```

Note that `handle_SIGINT: false` is required for debugging.