### PR TITLE
fix: correctly compute clickable points for elements inside OOPIFs

### DIFF
--- a/lib/puppeteer/element_handle/box_model.rb
+++ b/lib/puppeteer/element_handle/box_model.rb
@@ -2,12 +2,13 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
   class BoxModel
     QUAD_ATTRIBUTE_NAMES = %i(content padding border margin)
     # @param result [Hash]
-    def initialize(result_model)
+    # @param offset [Point]
+    def initialize(result_model, offset:)
       QUAD_ATTRIBUTE_NAMES.each do |attr_name|
         quad = result_model[attr_name.to_s]
         instance_variable_set(
           :"@#{attr_name}",
-          quad.each_slice(2).map { |x, y| Point.new(x: x, y: y) },
+          quad.each_slice(2).map { |x, y| Point.new(x: x, y: y) + offset },
         )
       end
       @width = result_model['width']

--- a/lib/puppeteer/frame_manager.rb
+++ b/lib/puppeteer/frame_manager.rb
@@ -178,7 +178,7 @@ class Puppeteer::FrameManager
     frame = @frames[event['targetInfo']['targetId']]
     session = Puppeteer::Connection.from_session(@client).session(event['sessionId'])
 
-    frame.send(:update_client, session)
+    frame&.send(:update_client, session)
     setup_listeners(session)
     async_init(session)
   end

--- a/lib/puppeteer/js_handle.rb
+++ b/lib/puppeteer/js_handle.rb
@@ -12,6 +12,7 @@ class Puppeteer::JSHandle
         context: context,
         client: context.client,
         remote_object: remote_object,
+        frame: frame,
         page: frame_manager.page,
         frame_manager: frame_manager,
       )

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -227,7 +227,7 @@ class Puppeteer::Page
     @client.send_message('Emulation.setGeolocationOverride', geolocation.to_h)
   end
 
-  attr_reader :javascript_enabled, :target
+  attr_reader :javascript_enabled, :target, :client
   alias_method :javascript_enabled?, :javascript_enabled
 
   def browser

--- a/spec/puppeteer/element_handle_spec.rb
+++ b/spec/puppeteer/element_handle_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe Puppeteer::ElementHandle do
         context: double(Puppeteer::ExecutionContext),
         client: double(Puppeteer::CDPSession),
         remote_object: double(Puppeteer::RemoteObject),
+        frame: double(Puppeteer::Frame),
         page: double(Puppeteer::Page),
         frame_manager: double(Puppeteer::FrameManager),
       )


### PR DESCRIPTION
Implement [13.1.0](https://github.com/puppeteer/puppeteer/releases/tag/v13.1.0) features. 2 PRs below:

* https://github.com/puppeteer/puppeteer/pull/7900
* https://github.com/puppeteer/puppeteer/pull/7906
* https://github.com/puppeteer/puppeteer/pull/7911