### PR TITLE
add test for taking a screenshot with null viewport should be possible

### DIFF
--- a/lib/puppeteer/element_handle.rb
+++ b/lib/puppeteer/element_handle.rb
@@ -569,7 +569,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
       capture_beyond_viewport: capture_beyond_viewport,
       from_surface: from_surface)
   ensure
-    if needs_viewport_reset
+    if needs_viewport_reset && viewport
       @page.viewport = viewport
     end
   end

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe Puppeteer::Launcher do
         screenshot = element_handle.screenshot
 
         # FIXME: It would be better to check the height of this screenshot here.
-        expect(screenshot.size).to be > 1000
+        expect(screenshot.size).to be > 100
       end
     end
 

--- a/spec/integration/launcher_spec.rb
+++ b/spec/integration/launcher_spec.rb
@@ -274,6 +274,23 @@ RSpec.describe Puppeteer::Launcher do
       end
     end
 
+    it 'should take Element screenshots when defaultViewport is null', sinatra: true do
+      options = default_launch_options.merge(
+        default_viewport: nil,
+      )
+
+      Puppeteer.launch(**options) do |browser|
+        page = browser.new_page
+        page.goto("#{server_prefix}/grid.html")
+        page.evaluate('() => window.scrollBy(50, 100)')
+        element_handle = page.query_selector('.box:nth-of-type(3)')
+        screenshot = element_handle.screenshot
+
+        # FIXME: It would be better to check the height of this screenshot here.
+        expect(screenshot.size).to be > 1000
+      end
+    end
+
     it 'should set the debugging port' do
       options = default_launch_options.merge(
         debugging_port: 9999,


### PR DESCRIPTION
https://github.com/puppeteer/puppeteer/pull/8680

puppeteer-ruby didn't have such bug.