### PR TITLE
fix: resolve target manager init if no existing targets detected

### DIFF
--- a/lib/puppeteer/chrome_target_manager.rb
+++ b/lib/puppeteer/chrome_target_manager.rb
@@ -33,7 +33,13 @@ class Puppeteer::ChromeTargetManager
     )
 
     setup_attachment_listeners(@connection)
-    @connection.async_send_message('Target.setDiscoverTargets', discover: true)
+    @connection.async_send_message('Target.setDiscoverTargets', {
+      discover: true,
+      filter: [
+        { type: 'tab', exclude: true },
+        {},
+      ],
+    })
   end
 
   def init


### PR DESCRIPTION
Porting https://github.com/puppeteer/puppeteer/pull/8748 and https://github.com/puppeteer/puppeteer/pull/8742