### PR TITLE
fix dot introduced in xpath expression

### DIFF
--- a/lib/puppeteer/element_handle.rb
+++ b/lib/puppeteer/element_handle.rb
@@ -609,14 +609,7 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
   # @param expression [String]
   # @return [Array<ElementHandle>]
   def Sx(expression)
-    param_xpath =
-      if expression.start_with?('//')
-        ".#{expression}"
-      else
-        expression
-      end
-
-    query_selector_all("xpath/#{param_xpath}")
+    query_selector_all("xpath/#{expression}")
   end
 
   define_async_method :async_Sx


### PR DESCRIPTION
One of my specs failing, due to '.' introduced into a xpath expression using element_handle#Sx.
There seems to be no reason for the '.', so i removed the code introducing the '.'.