### PR TITLE
Close the TCP socket explicitly

### DIFF
--- a/lib/puppeteer/web_socket.rb
+++ b/lib/puppeteer/web_socket.rb
@@ -45,6 +45,10 @@ class Puppeteer::WebSocket
     rescue Errno::ECONNRESET
       raise EOFError.new('closed by remote')
     end
+    
+    def dispose
+      @socket.close
+    end
   end
 
   STATE_CONNECTING = 0
@@ -107,6 +111,7 @@ class Puppeteer::WebSocket
     return if @ready_state >= STATE_CLOSING
     @ready_state = STATE_CLOSING
     @driver.close(reason, code)
+    @impl.dispose
   end
 
   def on_open(&block)


### PR DESCRIPTION
I had max open file problems on Mac, but I suppose the problem is on other platforms too.

I'm not familiar with the TCPSocket implementation but it looks like the socket is not being released if it's not explicitly closed, I read that it will be closed when it'll be read from or written to (and catch EOF or something like that), but it never seems to happen and the socket stays in a CLOSED state forever.

The way to reproduce was pretty much (in Rails console):

```
browser = Puppeteer.launch
browser.close
```

Then leave the Rails console open and run "lsof -n" on the PID of the Rails console and there will be a CLOSED TCP socket open like this:

```
ruby    26090 user   17u   IPv4 0xc6ba21f876ff5cbf      0t0                 TCP 127.0.0.1:60104->127.0.0.1:60103 (CLOSED)
```

If you start more in the same session, they'll pile up.

I'm not sure that there's a way to add an rspec test for this without lsof.