### PR TITLE
Accept multiple resolve for wait_for_response.

### DIFF
--- a/lib/puppeteer/lifecycle_watcher.rb
+++ b/lib/puppeteer/lifecycle_watcher.rb
@@ -100,7 +100,7 @@ class Puppeteer::LifecycleWatcher
     # Resolve previous navigation response in case there are multiple
     # navigation requests reported by the backend. This generally should not
     # happen by it looks like it's possible.
-    @navigation_response_received&.fulfill(nil)
+    @navigation_response_received.fulfill(nil) if @navigation_response_received && !@navigation_response_received.resolved?
     @navigation_response_received = resolvable_future
     if request.response && !@navigation_response_received.resolved?
       @navigation_response_received.fulfill(nil)


### PR DESCRIPTION
refs #263

```
WARN -- : Future can be resolved only once. It's [true, nil, nil], trying to set [true, nil, nil]. (Concurrent::MultipleAssignmentError)
/Users/yusuke-iwaki/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/promises.rb:1246:in `rejected_resolution'
/Users/yusuke-iwaki/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/promises.rb:692:in `resolve_with'
/Users/yusuke-iwaki/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/concurrent-ruby-1.1.10/lib/concurrent-ruby/concurrent/promises.rb:1365:in `fulfill'
/Users/yusuke-iwaki/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppeteer-ruby-0.44.1/lib/puppeteer/lifecycle_watcher.rb:103:in `handle_request'
/Users/yusuke-iwaki/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/puppeteer-ruby-0.44.1/lib/puppeteer/event_callbackable.rb:92:in `block in emit_event'

```