### PR TITLE
Fix codes compatible with Firefox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,5 +134,5 @@ workflows:
       - rspec_chrome_ruby3_1
       - rspec_chromium_alpine_3_0
       - rspec_chromium_alpine_3_1
-      # - rspec_firefox
-      # - rspec_firefox_pending_check
+      - rspec_firefox
+      - rspec_firefox_pending_check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ### main [[diff](https://github.com/YusukeIwaki/puppeteer-ruby/compare/0.44.2...main)]
 
-- xxx
+Bugfix
+
+- Revive Firefox automation :tada:
 
 ### 0.44.2 [[diff](https://github.com/YusukeIwaki/puppeteer-ruby/compare/0.44.1...0.44.2)]
 

--- a/lib/puppeteer/execution_context.rb
+++ b/lib/puppeteer/execution_context.rb
@@ -118,11 +118,11 @@ class Puppeteer::ExecutionContext
       ) # .catch(rewriteError);
 
       exception_details = result['exceptionDetails']
-      remote_object = Puppeteer::RemoteObject.new(result['result'])
-
       if exception_details
         raise EvaluationError.new("Evaluation failed: #{exception_details}")
       end
+
+      remote_object = Puppeteer::RemoteObject.new(result['result'])
 
       if @return_by_value
         remote_object.value

--- a/lib/puppeteer/firefox_target_manager.rb
+++ b/lib/puppeteer/firefox_target_manager.rb
@@ -66,9 +66,8 @@ class Puppeteer::FirefoxTargetManager
   end
 
   private def remove_session_listeners(session)
-    return unless @attachment_listener_ids
-    listener_ids = @attachment_listener_ids.delete(session)
-    return if listener_ids.empty?
+    listener_ids = @attachment_listener_ids&.delete(session)
+    return if !listener_ids || listener_ids.empty?
     session.remove_event_listener(*listener_ids)
   end
 

--- a/lib/puppeteer/frame.rb
+++ b/lib/puppeteer/frame.rb
@@ -310,7 +310,7 @@ class Puppeteer::Frame
 
     # Ensure loaderId updated.
     # The order of [Page.lifecycleEvent name="init"] and [Page.frameNavigated] is random... for some reason...
-    @loader_id = frame_payload['loaderId']
+    @loader_id = frame_payload['loaderId'] if frame_payload['loaderId']
   end
 
   # @param url [String]

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -1104,7 +1104,7 @@ class Puppeteer::Page
       quality: screenshot_options.quality,
       clip: clip,
       captureBeyondViewport: screenshot_options.capture_beyond_viewport?,
-      fromSurface: screenshot_options.from_surface?,
+      fromSurface: screenshot_options.from_surface,
     }.compact
     result = @client.send_message('Page.captureScreenshot', screenshot_params)
     reset_default_background_color if should_set_default_background

--- a/lib/puppeteer/page/screenshot_options.rb
+++ b/lib/puppeteer/page/screenshot_options.rb
@@ -105,15 +105,10 @@ class Puppeteer::Page
         else
           options[:capture_beyond_viewport]
         end
-      @from_surface =
-        if options[:from_surface].nil?
-          true
-        else
-          options[:from_surface]
-        end
+      @from_surface = options[:from_surface]
     end
 
-    attr_reader :type, :quality, :path, :clip, :encoding
+    attr_reader :type, :quality, :path, :clip, :encoding, :from_surface
 
     def full_page?
       @full_page
@@ -125,10 +120,6 @@ class Puppeteer::Page
 
     def capture_beyond_viewport?
       @capture_beyond_viewport
-    end
-
-    def from_surface?
-      @from_surface
     end
   end
 end

--- a/spec/integration/cookies_spec.rb
+++ b/spec/integration/cookies_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe 'cookies' do
       ])
     end
 
-    it_fails_firefox 'should get cookies from multiple urls' do
+    it 'should get cookies from multiple urls' do
       page.set_cookie(
         {
           url: 'https://foo.com',
@@ -250,21 +250,21 @@ RSpec.describe 'cookies' do
       expect { page.set_cookie(name: 'example-cookie', value: 'best') }.to raise_error(/At least one of the url and domain needs to be specified/)
     end
 
-    it_fails_firefox 'should default to setting secure cookie for HTTPS websites' do
+    it 'should default to setting secure cookie for HTTPS websites' do
       page.goto(server_empty_page)
       secure_url = 'https://example.com'
       page.set_cookie(url: secure_url, name: "foo", value: "bar")
       expect(page.cookies(secure_url)).to contain_exactly(include("secure" => true))
     end
 
-    it_fails_firefox 'should be able to set unsecure cookie for HTTP website' do
+    it 'should be able to set unsecure cookie for HTTP website' do
       page.goto(server_empty_page)
       http_url = 'http://example.com'
       page.set_cookie(url: http_url, name: "foo", value: "bar")
       expect(page.cookies(http_url)).to contain_exactly(include("secure" => false))
     end
 
-    it_fails_firefox 'should set a cookie on a different domain' do
+    it 'should set a cookie on a different domain' do
       page.goto(server_empty_page)
       page.set_cookie(
         url: 'https://www.example.com',

--- a/spec/integration/frame_spec.rb
+++ b/spec/integration/frame_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Puppeteer::Frame do
       expect(detached_frames.first).to be_detached
     end
 
-    it_fails_firefox 'should send "framenavigated" when navigating on anchor URLs' do
+    it 'should send "framenavigated" when navigating on anchor URLs' do
       page.goto(server_empty_page)
       Timeout.timeout(5) do
         framenavigated_promise = resolvable_future { |f| page.once('framenavigated') { |frame| f.fulfill(frame) } }
@@ -128,7 +128,7 @@ RSpec.describe Puppeteer::Frame do
       expect(has_events).to eq(false)
     end
 
-    it_fails_firefox 'should detach child frames on navigation' do
+    it 'should detach child frames on navigation' do
       attached_frames = []
       detached_frames = []
       navigated_frames = []
@@ -151,7 +151,7 @@ RSpec.describe Puppeteer::Frame do
       expect(navigated_frames.size).to eq(1)
     end
 
-    it_fails_firefox 'should support framesets' do
+    it 'should support framesets' do
       attached_frames = []
       detached_frames = []
       navigated_frames = []

--- a/spec/integration/input_spec.rb
+++ b/spec/integration/input_spec.rb
@@ -168,7 +168,7 @@ RSpec.describe 'input tests' do
       end
       chooser.accept(['file-does-not-exist.txt'])
     end
-    it 'should error on read of non-existent files' do
+    it_fails_firefox 'should error on read of non-existent files' do
       page.content = '<input type=file>'
       future {
         chooser = page.wait_for_file_chooser


### PR DESCRIPTION
Thanks to https://github.com/YusukeIwaki/puppeteer-ruby/pull/276, Firefox is now available.
Some codes are already broken. Fix them to work with Firefox.