### PR TITLE
Enable to register custom query handlers

### DIFF
--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -14,7 +14,7 @@
 * executablePath => `#executable_path`
 * launch
 * networkConditions => `#network_conditions`
-* ~~registerCustomQueryHandler~~
+* registerCustomQueryHandler => `#register_custom_query_handler`
 * ~~unregisterCustomQueryHandler~~
 
 ## ~~Accessibility~~


### PR DESCRIPTION
### Register a handler permanently

```ruby
      Puppeteer.register_custom_query_handler(
        name: 'getByClass',
        query_one: '(element, selector) => document.querySelector(`.${selector}`)',
        query_all: '(element, selector) => document.querySelectorAll(`.${selector}`)',
      )
```

### or, use a handler with block

```ruby
      Puppeteer.with_custom_query_handler(
        name: 'getByClass',
        query_one: '(element, selector) => document.querySelector(`.${selector}`)',
        query_all: '(element, selector) => document.querySelectorAll(`.${selector}`)',
      ) do
        button = page.query_selector('getByClass/btn')
        ...

      end # the handler is unregistered automatically
```