### PR TITLE
Remove BrowserFetcher

### DIFF
--- a/lib/puppeteer/browser_fetcher.rb
+++ b/lib/puppeteer/browser_fetcher.rb
@@ -1,6 +1,0 @@
-# Download latest chromium.
-class Puppeteer::BrowserFetcher
-  def initialize(project_root, options = {})
-    # 未実装
-  end
-end

--- a/lib/puppeteer/puppeteer.rb
+++ b/lib/puppeteer/puppeteer.rb
@@ -170,10 +170,4 @@ class Puppeteer::Puppeteer
     }.compact
     launcher.default_args(options)
   end
-
-  # @param {!BrowserFetcher.Options=} options
-  # @return {!BrowserFetcher}
-  def createBrowserFetcher(options = {})
-    BrowserFetcher.new(@project_root, options)
-  end
 end


### PR DESCRIPTION
puppeteer-ruby assumes the browser is prepared. BrowserFetcher is useless and remove it.