### PR TITLE
Explicitly set captureBeyondViewport=false unless fullPage or clip is set

### DIFF
--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -1095,6 +1095,8 @@ class Puppeteer::Page
           deviceScaleFactor: @viewport&.device_scale_factor || 1,
           screenOrientation: screen_orientation)
       end
+    elsif !clip
+      screenshot_options.unset_capture_beyond_viewport!
     end
 
     should_set_default_background = screenshot_options.omit_background? && format == 'png'

--- a/lib/puppeteer/page/screenshot_options.rb
+++ b/lib/puppeteer/page/screenshot_options.rb
@@ -121,5 +121,9 @@ class Puppeteer::Page
     def capture_beyond_viewport?
       @capture_beyond_viewport
     end
+
+    def unset_capture_beyond_viewport!
+      @capture_beyond_viewport = false
+    end
   end
 end

--- a/spec/integration/screenshot_spec.rb
+++ b/spec/integration/screenshot_spec.rb
@@ -176,6 +176,13 @@ RSpec.describe 'Screenshots' do
         page.screenshot(full_page: true)
         expect(page.eval_on_selector('textarea', 'input => input.value')).to eq('my value')
       }
+      it {
+        page.content = <<~HTML
+        <html><body>#{1000.times.map(&:to_s).join('<br/>')}</body></html>
+        HTML
+        screenshot = page.screenshot(full_page: false)
+        expect(screenshot.length).to be < 100000
+      }
     end
 
     context 'with Mobile viewport' do


### PR DESCRIPTION
resolves #298 

```ruby
Puppeteer.launch do |browser|
  page = browser.new_page
  page.viewport = Puppeteer::Viewport.new(width: 1280, height: 800)
  page.goto('https://github.com/YusukeIwaki')
  page.screenshot(path: 'YusukeIwaki.png', full_page: false)
end
```

outputs the image below
![YusukeIwaki](https://user-images.githubusercontent.com/11763113/213597103-ae49abcf-78cf-4c10-a58a-ddfd104cb726.png)

