### PR TITLE
Fixed websocket URL to work with windows google-chrome browser on WSL v1

### DIFF
--- a/lib/puppeteer/browser_runner.rb
+++ b/lib/puppeteer/browser_runner.rb
@@ -179,7 +179,7 @@ class Puppeteer::BrowserRunner
       loop do
         line = browser_process.stderr.readline
         /^DevTools listening on (ws:\/\/.*)$/.match(line) do |m|
-          return m[1]
+          return m[1].gsub(/\r/, '')
         end
         lines << line
       end


### PR DESCRIPTION
On WSLv1 when you set the "executable_path" to a windows browser the websocket url has a carriage return in it and it breaks the code.

`/usr/lib/ruby/3.0.0/uri/rfc3986_parser.rb:67:in `split': bad URI(is not URI?): "ws://127.0.0.1:59359/devtools/browser/7be24a1d-1c2e-4839-a3a9-2516e01e1d20\\r" (URI::InvalidURIError)
        from /usr/lib/ruby/3.0.0/uri/rfc3986_parser.rb:72:in `parse'
        from /usr/lib/ruby/3.0.0/uri/common.rb:171:in `parse'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/web_socket.rb:24:in `initialize'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/web_socket.rb:60:in `new'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/web_socket.rb:60:in `initialize'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/web_socket_transport.rb:5:in `new'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/web_socket_transport.rb:5:in `create'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/browser_runner.rb:167:in `setup_connection'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/launcher/chrome.rb:76:in `launch'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer/puppeteer.rb:78:in `launch'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer.rb:86:in `public_send'
        from /var/lib/gems/3.0.0/gems/puppeteer-ruby-0.45.3/lib/puppeteer.rb:86:in `block (3 levels) in <module:Puppeteer>'
        from get-pin.rb:5:in `get_browser'
        from get-pin.rb:34:in `<main>'`

my change fixes that 

