### PR TITLE
Handle IOError in `readpartial`

### DIFF
--- a/lib/puppeteer/web_socket.rb
+++ b/lib/puppeteer/web_socket.rb
@@ -42,7 +42,7 @@ class Puppeteer::WebSocket
 
     def readpartial(maxlen = 1024)
       @socket.readpartial(maxlen)
-    rescue Errno::ECONNRESET
+    rescue Errno::ECONNRESET, IOError
       raise EOFError.new('closed by remote')
     end
     


### PR DESCRIPTION
Works around https://github.com/YusukeIwaki/puppeteer-ruby/issues/337 and https://github.com/YusukeIwaki/puppeteer-ruby/issues/319.