### PR TITLE
add missing kwarg to Puppeteer#launch, fix #341

### DIFF
--- a/lib/puppeteer/puppeteer.rb
+++ b/lib/puppeteer/puppeteer.rb
@@ -21,6 +21,7 @@ class Puppeteer::Puppeteer
   # @param dumpio [Boolean]
   # @param env [Hash]
   # @param pipe [Boolean]
+  # @param extra_prefs_firefox [Hash]
   # @param args [Array<String>]
   # @param user_data_dir [String]
   # @param devtools [Boolean]
@@ -41,6 +42,7 @@ class Puppeteer::Puppeteer
     dumpio: nil,
     env: nil,
     pipe: nil,
+    extra_prefs_firefox: nil,
     args: nil,
     user_data_dir: nil,
     devtools: nil,
@@ -61,6 +63,7 @@ class Puppeteer::Puppeteer
       dumpio: dumpio,
       env: env,
       pipe: pipe,
+      extra_prefs_firefox: extra_prefs_firefox,
       args: args,
       user_data_dir: user_data_dir,
       devtools: devtools,

--- a/spec/puppeteer/launcher/launch_options_spec.rb
+++ b/spec/puppeteer/launcher/launch_options_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Puppeteer::Launcher::LaunchOptions do
     it 'pipe: false' do
       expect(subject.pipe?).to eq(false)
     end
+
+    it 'extra_prefs_firefox: {}' do
+      expect(subject.extra_prefs_firefox).to eq({})
+    end
   end
 
   describe "disabled signal handlers" do

--- a/spec/puppeteer_spec.rb
+++ b/spec/puppeteer_spec.rb
@@ -1,3 +1,26 @@
+KEYWORDS = %i[
+  product
+  channel
+  executable_path
+  ignore_default_args
+  handle_SIGINT
+  handle_SIGTERM
+  handle_SIGHUP
+  timeout
+  dumpio
+  env
+  pipe
+  extra_prefs_firefox
+  args
+  user_data_dir
+  devtools
+  debugging_port
+  headless
+  ignore_https_errors
+  default_viewport
+  slow_mo
+]
+
 RSpec.describe Puppeteer do
   it 'has a version number' do
     expect(Puppeteer::VERSION).not_to be nil
@@ -6,6 +29,12 @@ RSpec.describe Puppeteer do
   describe '#launch' do
     it 'returns an instance of Browser' do
       expect(Puppeteer.launch).to be_a(Puppeteer::Browser)
+    end
+
+    KEYWORDS.each do |keyword|
+      it "returns an instance of Browser if instantiated with the :#{keyword} kwarg" do
+        expect(Puppeteer.launch(**{ keyword => nil })).to be_a(Puppeteer::Browser)
+      end
     end
   end
 end


### PR DESCRIPTION
`:extra_prefs_firefox` was missing from `Puppeteer#launch` method kwargs. Added test to check Puppeteer class can be instantiated with all kwargs - couldn't see the list hard coded anywhere.