### PR TITLE
Add porting plan for Node.js Puppeteer fidelity with socketry/async

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,21 @@
 - Enable required CDP domains before relying on their events (see `CLAUDE/cdp_protocol.md`).
 - Update `docs/api_coverage.md` when new APIs are added.
 - `CHANGELOG.md` is being retired; do not update it for new changes.
+- Porting plan (CDP + async):
+  - Aim for Node.js Puppeteer fidelity, but use `socketry/async` (like puppeteer-bidi) instead of JS async/await.
+  - Use puppeteer-bidi as the Ruby porting reference: follow its approach and patterns.
+  - For `Puppeteer::Page`, mirror upstream `api/Page.ts` and `cdp/Page.ts`, similar to how puppeteer-bidi uses `api/Page.ts` + `bidi/Page.ts`.
+  - Follow puppeteer-bidi's `Page` patterns: wrap `:request` handlers to enqueue interception actions (WeakMap to keep `on/off` mapping), serialize interception with `Async::Semaphore`, and keep `Page` mostly as a thin delegator to `Frame`.
+  - Mirror upstream timeout/deferred behavior with `Async::Promise` + `AsyncUtils.async_timeout` (timeout 0 = infinite) and keep error messages aligned (e.g., file chooser/network idle).
+  - Screenshot parity: apply default option behavior and clip rounding (`normalize/round`), and convert clip coordinates when `captureBeyondViewport` is false (visualViewport offsets).
+  - `evaluate_on_new_document`: build IIFE expressions and serialize args the same way as puppeteer-bidi's `build_evaluation_expression`/`serialize_arg_for_preload`.
+  - `wait_for_network_idle`: track inflight requests and reset idle timers on changes (mirrors Page.ts inflight counter logic).
+  - RxJS Observable flows are replaced with manual EventEmitter listeners + `Async::Promise` (no `fromEmitterEvent`/`merge`/`timeout`), so compose waits explicitly (e.g., `wait_for_navigation`, `set_content`).
+  - Use `AsyncUtils` (Barrier-based Promise.all/race + `async_timeout`) instead of RxJS `combineLatest`/`firstValueFrom`/`timeout`.
+  - `WaitTask`/`TaskManager` mirror Puppeteer's polling waits; no AbortSignal, use Async tasks + cancellation.
+  - `ReactorRunner` runs a dedicated Async reactor thread and proxies sync calls into it (wrap/unwrap).
+  - Use `Core::EventEmitter` + symbols instead of RxJS event streams; clean up listeners explicitly.
+  - Disposable patterns: `Core::Disposable::DisposableStack`/`DisposableMixin` stand in for JS DisposableStack/AsyncDisposableStack.
 
 ## Security & Configuration Tips
 


### PR DESCRIPTION
## Summary

- Document the approach for aligning puppeteer-ruby implementation more closely with the upstream Node.js Puppeteer
- Use socketry/async as the concurrency model (similar to puppeteer-bidi's approach)
- Define key patterns and utilities to implement

## Key Points

- Use puppeteer-bidi as the Ruby porting reference
- Mirror upstream Page.ts patterns (api/ + cdp/ layers)  
- Replace RxJS Observable flows with EventEmitter + Async::Promise
- Implement AsyncUtils for Promise.all/race/timeout behavior
- Add WaitTask/TaskManager for polling waits
- Use ReactorRunner for dedicated Async reactor thread
- Implement Disposable patterns for resource cleanup

## Test plan

- [ ] Review the documented approach
- [ ] Validate alignment with puppeteer-bidi patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)