### PR TITLE
Port click tests from Puppeteer TypeScript test suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,11 @@ bundle exec rspec spec/integration/page_spec.rb
 DEBUG=1 bundle exec rspec spec/integration/page_spec.rb
 ```
 
+> **Note for Codex CLI**: When executing RSpec from Codex CLI, always use `rbenv exec`:
+> ```bash
+> rbenv exec bundle exec rspec spec/integration/click_spec.rb
+> ```
+
 ### Key Environment Variables
 
 | Variable | Description |

--- a/CLAUDE/porting_puppeteer.md
+++ b/CLAUDE/porting_puppeteer.md
@@ -85,36 +85,51 @@ Translate the TypeScript to idiomatic Ruby:
 
 ```ruby
 # lib/puppeteer/frame.rb
-def click(selector, delay: nil, button: nil, click_count: nil)
+def click(selector, delay: nil, button: nil, click_count: nil, count: nil)
   handle = query_selector(selector)
   raise ArgumentError, "No element found for selector: #{selector}" unless handle
 
   begin
-    handle.click(delay: delay, button: button, click_count: click_count)
+    handle.click(delay: delay, button: button, click_count: click_count, count: count)
   ensure
     handle.dispose
   end
 end
 
 # lib/puppeteer/element_handle.rb
-def click(delay: nil, button: nil, click_count: nil, offset: nil)
+def click(delay: nil, button: nil, click_count: nil, count: nil, offset: nil)
   scroll_into_view_if_needed
   point = clickable_point(offset: offset)
   @page.mouse.click(point.x, point.y,
     delay: delay,
     button: button,
-    click_count: click_count
+    click_count: click_count,
+    count: count
   )
 end
 
 # lib/puppeteer/mouse.rb
-def click(x, y, delay: nil, button: nil, click_count: nil)
+def click(x, y, delay: nil, button: nil, click_count: nil, count: nil)
   move(x, y)
   down(button: button, click_count: click_count)
   sleep(delay / 1000.0) if delay
   up(button: button, click_count: click_count)
 end
 ```
+
+Note: `click_count` is deprecated (mirrors Puppeteer's `clickCount` deprecation). Use `count` for multiple clicks and let `click_count` default to `count`.
+
+### Mouse Button Types
+
+The `button` parameter accepts these values (defined in `Puppeteer::Mouse::Button`):
+
+| Value | Button Code | Description |
+|-------|-------------|-------------|
+| `'left'` | 0 | Primary button (default) |
+| `'right'` | 2 | Secondary button (context menu) |
+| `'middle'` | 1 | Auxiliary button (wheel click) |
+| `'back'` | 3 | Browser back button |
+| `'forward'` | 4 | Browser forward button |
 
 ### Key Translation Patterns
 

--- a/CLAUDE/testing.md
+++ b/CLAUDE/testing.md
@@ -99,6 +99,25 @@ RSpec.describe 'BrowserContext', browser_context: :incognito do
 end
 ```
 
+### OOPIF (Out-of-Process IFrame) Tests
+
+For tests requiring cross-process iframes, use `enable_site_per_process_flag: true`:
+
+```ruby
+it 'clicks button in cross-process iframe', enable_site_per_process_flag: true do
+  with_test_state do |page:, server:, **|
+    page.goto(server.empty_page)
+    # Use cross_process_prefix (127.0.0.1) instead of prefix (localhost)
+    attach_frame(page, 'frame-id', "#{server.cross_process_prefix}/input/button.html")
+
+    frame = page.frames[1]
+    frame.click('button')
+  end
+end
+```
+
+This metadata launches Chrome with `--site-per-process` and `--host-rules=MAP * 127.0.0.1` flags.
+
 ## Running Tests
 
 ### Basic Commands

--- a/lib/puppeteer/element_handle.rb
+++ b/lib/puppeteer/element_handle.rb
@@ -364,13 +364,14 @@ class Puppeteer::ElementHandle < Puppeteer::JSHandle
 
   # @rbs delay: Numeric? -- Delay between down and up (ms)
   # @rbs button: String? -- Mouse button
-  # @rbs click_count: Integer? -- Click count to report
+  # @rbs click_count: Integer? -- Deprecated: use count (click_count only sets clickCount)
+  # @rbs count: Integer? -- Number of clicks to perform
   # @rbs offset: Puppeteer::ElementHandle::Offset | Hash[Symbol, Numeric] | nil -- Click offset
   # @rbs return: void -- No return value
-  def click(delay: nil, button: nil, click_count: nil, offset: nil)
+  def click(delay: nil, button: nil, click_count: nil, count: nil, offset: nil)
     scroll_into_view_if_needed
     point = clickable_point(offset)
-    @page.mouse.click(point.x, point.y, delay: delay, button: button, click_count: click_count)
+    @page.mouse.click(point.x, point.y, delay: delay, button: button, click_count: click_count, count: count)
   end
 
   define_async_method :async_click

--- a/lib/puppeteer/frame.rb
+++ b/lib/puppeteer/frame.rb
@@ -237,10 +237,11 @@ class Puppeteer::Frame
   # @rbs selector: String -- CSS selector
   # @rbs delay: Numeric? -- Delay between down and up (ms)
   # @rbs button: String? -- Mouse button
-  # @rbs click_count: Integer? -- Click count to report
+  # @rbs click_count: Integer? -- Deprecated: use count (click_count only sets clickCount)
+  # @rbs count: Integer? -- Number of clicks to perform
   # @rbs return: void -- No return value
-  def click(selector, delay: nil, button: nil, click_count: nil)
-    @puppeteer_world.click(selector, delay: delay, button: button, click_count: click_count)
+  def click(selector, delay: nil, button: nil, click_count: nil, count: nil)
+    @puppeteer_world.click(selector, delay: delay, button: button, click_count: click_count, count: count)
   end
 
   define_async_method :async_click

--- a/lib/puppeteer/isolated_world.rb
+++ b/lib/puppeteer/isolated_world.rb
@@ -355,10 +355,11 @@ class Puppeteer::IsolaatedWorld
   # @param selector [String]
   # @param delay [Number]
   # @param button [String] "left"|"right"|"middle"
-  # @param click_count [Number]
-  def click(selector, delay: nil, button: nil, click_count: nil)
+  # @param click_count [Number] Deprecated: use count (click_count only sets clickCount)
+  # @param count [Number]
+  def click(selector, delay: nil, button: nil, click_count: nil, count: nil)
     handle = query_selector(selector) or raise ElementNotFoundError.new(selector)
-    handle.click(delay: delay, button: button, click_count: click_count)
+    handle.click(delay: delay, button: button, click_count: click_count, count: count)
     handle.dispose
   end
 

--- a/lib/puppeteer/mouse.rb
+++ b/lib/puppeteer/mouse.rb
@@ -102,10 +102,11 @@ class Puppeteer::Mouse
   # @rbs y: Numeric -- Y coordinate
   # @rbs delay: Numeric? -- Delay between down and up (ms)
   # @rbs button: String? -- Mouse button
-  # @rbs click_count: Integer? -- Click count to report
+  # @rbs click_count: Integer? -- Deprecated: use count (click_count only sets clickCount)
   # @rbs count: Integer? -- Number of click repetitions
   # @rbs return: void -- No return value
   def click(x, y, delay: nil, button: nil, click_count: nil, count: nil)
+    warn_deprecated_click_count if !click_count.nil?
     count ||= 1
     click_count ||= count
     if count < 1
@@ -129,6 +130,19 @@ class Puppeteer::Mouse
   end
 
   define_async_method :async_click
+
+  private def warn_deprecated_click_count
+    return if self.class.deprecated_click_count_warned
+
+    self.class.deprecated_click_count_warned = true
+    warn('DEPRECATED: `click_count` is deprecated; use `count` instead.')
+  end
+
+  class << self
+    attr_accessor :deprecated_click_count_warned
+  end
+
+  self.deprecated_click_count_warned = false
 
   # @rbs button: String? -- Mouse button
   # @rbs click_count: Integer? -- Click count to report

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -1334,10 +1334,11 @@ class Puppeteer::Page
   # @rbs selector: String -- CSS selector
   # @rbs delay: Numeric? -- Delay between down and up (ms)
   # @rbs button: String? -- Mouse button
-  # @rbs click_count: Integer? -- Click count to report
+  # @rbs click_count: Integer? -- Deprecated: use count (click_count only sets clickCount)
+  # @rbs count: Integer? -- Number of clicks to perform
   # @rbs return: void -- No return value
-  def click(selector, delay: nil, button: nil, click_count: nil)
-    main_frame.click(selector, delay: delay, button: button, click_count: click_count)
+  def click(selector, delay: nil, button: nil, click_count: nil, count: nil)
+    main_frame.click(selector, delay: delay, button: button, click_count: click_count, count: count)
   end
 
   define_async_method :async_click

--- a/spec/assets/input/scrollable.html
+++ b/spec/assets/input/scrollable.html
@@ -12,8 +12,22 @@
             button.id = 'button-' + i;
             button.onclick = () => button.textContent = 'clicked';
             button.oncontextmenu = event => {
+              if (![2].includes(event.button)) {
+                return;
+              }
               event.preventDefault();
               button.textContent = 'context menu';
+            }
+            button.onmouseup = event => {
+              if (![1,3,4].includes(event.button)) {
+                return;
+              }
+              event.preventDefault();
+              button.textContent = {
+                3: 'back click',
+                4: 'forward click',
+                1: 'aux click',
+              }[event.button];
             }
             document.body.appendChild(button);
             document.body.appendChild(document.createElement('br'));


### PR DESCRIPTION
## Summary

- Port 8 missing click tests from [puppeteer/puppeteer click.spec.ts](https://github.com/puppeteer/puppeteer/blob/main/test/src/click.spec.ts) to the Ruby implementation
- Add `count` parameter to click methods across Page, Frame, IsolatedWorld, and ElementHandle
- Deprecate `click_count` parameter in favor of `count` (with deprecation warning)
- Update `scrollable.html` asset with `onmouseup` handler for aux/back/forward mouse button tests
- Update `CLAUDE/` documentation:
  - `porting_puppeteer.md`: `count` parameter, mouse button types table
  - `testing.md`: OOPIF test metadata (`enable_site_per_process_flag`)

### New Tests Added

| Test Name | Description |
|-----------|-------------|
| should not throw UnhandledPromiseRejection when page closes | Tests graceful handling of race conditions |
| should scroll and click with disabled javascript | Validates scrolling + click with JS disabled |
| should click half-offscreen elements | Tests clicking partially visible elements |
| should double multiple times | Validates consecutive double-clicks |
| should fire aux event on middle click | Tests middle mouse button |
| should fire back click | Tests back mouse button |
| should fire forward click | Tests forward mouse button |
| should click the button with fixed position inside an iframe | Tests fixed-position elements in cross-process iframes |

### API Changes

- `count` parameter added to `Page#click`, `Frame#click`, `ElementHandle#click`
- `click_count` is now deprecated (mirrors Puppeteer's deprecation of `clickCount`)

## Test plan

- [x] Run `bundle exec rspec spec/integration/click_spec.rb` - all 30 tests pass
- [x] Run `bundle exec rubocop` - no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)