### PR TITLE
Port input tests from Puppeteer TypeScript test suite

### DIFF
--- a/lib/puppeteer/file_chooser.rb
+++ b/lib/puppeteer/file_chooser.rb
@@ -25,5 +25,11 @@ class Puppeteer::FileChooser
       raise 'Cannot cancel FileChooser which is already handled!'
     end
     @handled = true
+    js = <<~JAVASCRIPT
+    (element) => {
+      element.dispatchEvent(new Event('cancel', { bubbles: true }));
+    }
+    JAVASCRIPT
+    @element.evaluate(js)
   end
 end

--- a/lib/puppeteer/page.rb
+++ b/lib/puppeteer/page.rb
@@ -218,14 +218,6 @@ class Puppeteer::Page
     end
   end
 
-  class FileChooserTimeoutError < Puppeteer::Error
-    # @rbs timeout: Numeric -- Timeout in milliseconds
-    # @rbs return: void -- No return value
-    def initialize(timeout:)
-      super("waiting for filechooser failed: timeout #{timeout}ms exceeded")
-    end
-  end
-
   # @rbs timeout: Numeric? -- Timeout in milliseconds
   # @rbs return: Puppeteer::FileChooser -- File chooser handle
   def wait_for_file_chooser(timeout: nil)
@@ -244,7 +236,7 @@ class Puppeteer::Page
         Puppeteer::AsyncUtils.async_timeout(option_timeout, promise).wait
       end
     rescue Async::TimeoutError
-      raise FileChooserTimeoutError.new(timeout: option_timeout)
+      raise Puppeteer::TimeoutError.new("Waiting for `FileChooser` failed: #{option_timeout}ms exceeded")
     ensure
       @file_chooser_interceptors.delete(promise)
     end

--- a/spec/integration/input_ext_spec.rb
+++ b/spec/integration/input_ext_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe 'Input (white-box / Ruby-specific)' do
+  it 'dispatches cancel event when FileChooser is canceled' do
+    with_test_state do |page:, **|
+      page.content = '<input type=file>'
+      page.evaluate(<<~JAVASCRIPT)
+      () => {
+        const input = document.querySelector('input');
+        globalThis.cancelEventFired = false;
+        input.addEventListener('cancel', () => {
+          globalThis.cancelEventFired = true;
+        });
+      }
+      JAVASCRIPT
+
+      chooser = page.wait_for_file_chooser do
+        page.click('input')
+      end
+      chooser.cancel
+
+      expect(page.evaluate('() => globalThis.cancelEventFired')).to eq(true)
+    end
+  end
+end

--- a/spec/integration/input_spec.rb
+++ b/spec/integration/input_spec.rb
@@ -89,21 +89,21 @@ RSpec.describe 'input tests' do
 
     it 'should respect timeout' do
       with_test_state do |page:, **|
-        expect { page.wait_for_file_chooser(timeout: 1) }.to raise_error(/waiting for filechooser failed: timeout 1ms exceeded/)
+        expect { page.wait_for_file_chooser(timeout: 1) }.to raise_error(Puppeteer::TimeoutError)
       end
     end
 
     it 'should respect default timeout when there is no custom timeout' do
       with_test_state do |page:, **|
         page.default_timeout = 1
-        expect { page.wait_for_file_chooser }.to raise_error(/waiting for filechooser failed: timeout 1ms exceeded/)
+        expect { page.wait_for_file_chooser }.to raise_error(Puppeteer::TimeoutError)
       end
     end
 
     it 'should prioritize exact timeout over default timeout' do
       with_test_state do |page:, **|
         page.default_timeout = 0
-        expect { page.wait_for_file_chooser(timeout: 1) }.to raise_error(/waiting for filechooser failed: timeout 1ms exceeded/)
+        expect { page.wait_for_file_chooser(timeout: 1) }.to raise_error(Puppeteer::TimeoutError)
       end
     end
 


### PR DESCRIPTION
## Summary

- Rename describe block from `input` to `ElementHandle#upload_file` for consistency with TypeScript Puppeteer
- Split combined upload test into two separate tests for better test isolation:
  - `should upload the file` (tests filename, type, events)
  - `should read the file` (tests FileReader content)
- Add explicit `with_test_state` blocks for proper test isolation
- Add comment noting AbortController test cannot be ported (Ruby limitation - `wait_for_file_chooser` only accepts `timeout:` parameter)
- Update `should prioritize exact timeout over default timeout` to use `default_timeout=0` matching TypeScript behavior
- Add `timeout: 0` to `should work with no timeout` test matching TypeScript

### Additional improvements

- **FileChooser#cancel**: Now dispatches a proper 'cancel' event on the element (matches browser behavior)
- **Timeout error handling**: Replace custom `FileChooserTimeoutError` with standard `Puppeteer::TimeoutError` for consistency
- **New test file**: Add `spec/integration/input_ext_spec.rb` with Ruby-specific test verifying cancel event dispatch

## Test plan

- [ ] Run `bundle exec rspec spec/integration/input_spec.rb` to verify all input tests pass
- [ ] Run `bundle exec rspec spec/integration/input_ext_spec.rb` to verify Ruby-specific tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)